### PR TITLE
Fail and do nothing if options parsing fails

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -8,6 +8,7 @@ Copyright 2009      George Danchev <danchev@spnet.net>
 Copyright 2009      James Cameron <quozl@us.netrek.org>
 Copyright 2010      Ibragimov Rinat <ibragimovrinat@mail.ru>
 Copyright 2017      Stoney Sauce <stoneysauce@gmail.com>
+Copyright 2019      Daniel Lublin <daniel@lublin.se>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -124,6 +125,8 @@ scrot_parse_option_array(int argc, char **argv)
         case 'a':
 	  options_parse_autoselect(optarg);
 	   break;
+        case '?':
+           exit(EXIT_FAILURE);
         default:
            break;
       }


### PR DESCRIPTION
For example, passing `-t` (thumbnail) without an argument would
previously both print that required arg is missing *and* continue saving
a screenshot!