### PR TITLE
Implemented draw text.

### DIFF
--- a/man/scrot.1
+++ b/man/scrot.1
@@ -106,6 +106,11 @@ By default \fBscrot\fP does not overwrite the files, use this option to allow it
 \fB-l\fP, \fB--line\fP
 Indicates the style of the line when the selection is used: \fB--select\fP
 See SELECTION STYLE
+.TP
+.B
+\fB-n\fP, \fB--note\fP
+Draw a text note.
+See NOTE FORMAT
 .SH SPECIAL STRINGS
 
 Both the \fB--exec\fP and filename parameters can take format specifiers that are
@@ -155,10 +160,26 @@ The following specifiers are recognised:
 The default style are:
 style=solid,width=1
 .SH EXAMPLE
-.TP
-.B
-\fBscrot\fP
-\fB--line\fP style=dash,width=3 \fB--select\fP
+\fBscrot\fP \fB--line\fP style=dash,width=3 \fB--select\fP
+.RE
+.PP
+
+.SH NOTE FORMAT
+
+The following specifiers are recognised for the option \fB--note\fP
+.PP
+.nf
+.fam C
+    -f 'FontName/size'
+    -t 'text'
+    -x position (optional)
+    -y position (optional)
+    -c color(RGBA) (optional)
+
+.fam T
+.fi
+.SH EXAMPLE
+\fBscrot\fP \fB--note\fP "\fB-f\fP '/usr/share/fonts/TTF/DroidSans-Bold/40' \fB-x\fP 10 \fB-y\fP 20 \fB-c\fP 255,0,0,255 \fB-t\fP 'Hi'"
 .SH AUTHOR
 \fBscrot\fP was originally developed by Tom Gilbert under MIT-advertising license.
 .PP

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -43,6 +43,8 @@ OPTIONS
   -o, --overwrite    By default scrot does not overwrite the files, use this option to allow it.
   -l, --line         Indicates the style of the line when the selection is used: --select
                      See SELECTION STYLE
+  -n, --note         Draw a text note.
+                     See NOTE FORMAT
 
 SPECIAL STRINGS
 
@@ -82,7 +84,21 @@ SELECTION STYLE
   The default style are:
                   style=solid,width=1
 EXAMPLE
- scrot  --line style=dash,width=3 --select
+  scrot --line style=dash,width=3 --select
+
+
+NOTE FORMAT
+
+  The following specifiers are recognised for the option --note
+
+    -f 'FontName/size'
+    -t 'text'
+    -x position (optional)
+    -y position (optional)
+    -c color(RGBA) (optional)
+
+EXAMPLE
+  scrot --note "-f '/usr/share/fonts/TTF/DroidSans-Bold/40' -x 10 -y 20 -c 255,0,0,255 -t 'Hi'"
 
 AUTHOR
   scrot was originally developed by Tom Gilbert under MIT-advertising license.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,5 +33,5 @@ LIBOBJS = @LIBOBJS@
 
 bin_PROGRAMS      = scrot
 scrot_SOURCES       = main.c getopt.c getopt1.c getopt.h scrot.h \
-options.c options.h debug.h imlib.c structs.h
+options.c options.h debug.h imlib.c structs.h note.c note.h
 scrot_LDADD         = -lX11 -lXfixes -lXcursor @GIBLIB_LIBS@

--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,9 @@ main(int argc,
     }
   }
 
+  if (opt.note != NULL)
+    scrot_note_draw(image);
+
   if (!image)
     gib_eprintf("no image grabbed");
 
@@ -279,6 +282,9 @@ scrot_grab_shot(void)
                                          scr->height, 1);
   if (opt.pointer == 1)
     scrot_grab_mouse_pointer(im, 0, 0);
+
+  if (opt.note != NULL)
+    scrot_note_draw(im);
 
   return im;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -136,6 +136,8 @@ main(int argc,
       gib_eprintf("Unable to create scaled Image\n");
     else
     {
+      if (opt.note != NULL)
+        scrot_note_draw(image);
       filename_thumb = im_printf(opt.thumb_file, tm, NULL, NULL, thumbnail);
       scrot_check_if_overwrite_file(&filename_thumb);
       gib_imlib_save_image_with_error_return(thumbnail, filename_thumb, &err);
@@ -282,9 +284,6 @@ scrot_grab_shot(void)
                                          scr->height, 1);
   if (opt.pointer == 1)
     scrot_grab_mouse_pointer(im, 0, 0);
-
-  if (opt.note != NULL)
-    scrot_note_draw(im);
 
   return im;
 }

--- a/src/note.c
+++ b/src/note.c
@@ -61,7 +61,7 @@ void scrot_note_new(char *format)
 {
    scrot_note_free();
 
-   note = (scrotnote){NULL,NULL,0,0,{COLOR_OPTIONAL,0,0,0,0}};
+   note = (scrotnote){NULL,NULL,0,0,0.0,{COLOR_OPTIONAL,0,0,0,0}};
 
    char *const end = format + strlen(format);
 
@@ -115,6 +115,14 @@ malformed:
      case 'y': {
         if ((1 != sscanf(tok, "%d", &note.y)) || (note.y < 0)) {
            fprintf(stderr, "Error --note option : Malformed syntax for -y\n");
+           exit(EXIT_FAILURE);
+        }
+        next_not_space(&tok);
+     }
+     break;
+     case 'a': {
+        if ((1 != sscanf(tok, "%lf", &note.angle))) {
+           fprintf(stderr, "Error --note option : Malformed syntax for -a\n");
            exit(EXIT_FAILURE);
         }
         next_not_space(&tok);
@@ -191,8 +199,13 @@ void scrot_note_free(void)
 
 void scrot_note_draw(Imlib_Image im)
 {
+   if (NULL == im) return;
+
    imlib_context_set_image(im);
    imlib_context_set_font(imfont);
+
+   imlib_context_set_direction(IMLIB_TEXT_TO_ANGLE);
+   imlib_context_set_angle(note.angle);
 
    if (note.color.status == COLOR_OK)
       imlib_context_set_color(note.color.r,

--- a/src/note.c
+++ b/src/note.c
@@ -68,7 +68,7 @@ void scrot_note_new(char *format)
      break;
      case 't':
      {
-            if (tok[0] != '\'' || tok[0] == '\0') break;
+            if (tok[0] != '\'') break;
 
             char *end = strchr(++tok, '\'');
 

--- a/src/note.c
+++ b/src/note.c
@@ -194,8 +194,8 @@ void load_font(void)
    imfont = imlib_load_font(note.font);
 
    if (!imfont) {
-      scrot_note_free();
       fprintf(stderr, "Failed to load fontname: %s\n", note.font);
+      scrot_note_free();
       exit(EXIT_FAILURE);
    }
 }

--- a/src/note.c
+++ b/src/note.c
@@ -1,0 +1,200 @@
+/* note.c
+
+Copyright 2019  Daniel T. Borelli <danieltborelli@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+
+#include <assert.h>
+#include <stdint.h>
+
+#include "scrot.h"
+
+scrotnote note;
+
+static Imlib_Font imfont = NULL;
+
+static void load_font(void);
+
+
+void scrot_note_new(char *format)
+{
+   scrot_note_free();
+
+   note = (scrotnote){NULL, NULL, -1, -1, -1, {0,0}};
+
+   char *tok = strtok(format, ":");
+
+   while (tok) {
+     const char type = tok[0];
+
+     switch(type) {
+     case 'f':
+        if (tok[1] == '=') {
+           if (-1 == sscanf(tok, "f=%m[^/]/%d", &note.font, &note.size)) {
+              free(note.font);
+              note.font = NULL;
+              note.size = -1;
+            }
+        }
+     break;
+     case 'x':
+        if (tok[1] == '=') {
+           if (-1 == sscanf(tok, "x=%d", &note.x))
+              note.x = -1;
+        }
+     break;
+     case 'y':
+        if (tok[1] == '=') {
+           if (-1 == sscanf(tok, "y=%d", &note.y))
+              note.y = -1;
+        }
+     break;
+     case 't':
+        if (tok[1] == '=') {
+            const size_t size = strlen(tok) - 2;
+            note.text = malloc(size + 1);
+            assert(NULL != note.text);
+            strncpy(note.text, tok + 2, size);
+            note.text[size] = '\0';
+        }
+     break;
+     case 'c':
+        if (tok[1] == '=') {
+           char *saveptr;
+           char *c = strtok_r(tok + 2, ",", &saveptr);
+
+           while (c) {
+
+              int color = options_parse_required_number(c);
+
+              if ((color < 0) || color > 255) {
+                 fprintf(stderr, "color '%d' out of range 0..255\n", color);
+                 note.color.n = -1;
+                 break;
+              }
+
+              note.color.n++;
+
+              switch(note.color.n) {
+              case 1 : note.color.r = color;
+              case 2 : note.color.g = color;
+              case 3 : note.color.b = color;
+              case 4 : note.color.a = color;
+              }
+
+              c = strtok_r(NULL, ",", &saveptr);
+           }
+
+           if (note.color.n != 4)
+              note.color.n = -1;
+        }
+     break;
+     default:
+      fprintf(stderr, "Malformed syntax, unknown option: %c\n", tok[0]);
+      scrot_note_free();
+      exit(EXIT_FAILURE);
+     }
+
+     tok = strtok(NULL, ":");
+   }
+
+   int error = 0;
+
+   if (!note.font || note.size < 0) {
+      fprintf(stderr, "Malformed syntax for f=\n");
+      error = 1;
+   }
+
+   if (!note.text) {
+      fprintf(stderr, "Malformed syntax for t=\n");
+      error = 1;
+   }
+
+   if (note.x < 0) {
+      fprintf(stderr, "Malformed syntax for x=\n");
+      error = 1;
+   }
+
+   if (note.y < 0) {
+      fprintf(stderr, "Malformed syntax for y=\n");
+      error = 1;
+   }
+
+   if (note.color.n == -1) {
+      fprintf(stderr, "Malformed syntax for c=\n");
+      error = 1;
+   }
+
+   if (error) {
+      scrot_note_free();
+      exit(EXIT_FAILURE);
+   }
+
+   load_font();
+
+}
+
+void scrot_note_free(void)
+{
+    if (note.text) (free(note.text), note.text = NULL);
+    if (note.font) (free(note.font), note.font = NULL);
+
+    if (imfont) {
+       imlib_context_set_font(imfont);
+       imlib_free_font();
+    }
+}
+
+
+void scrot_note_draw(Imlib_Image im)
+{
+   imlib_context_set_image(im);
+   imlib_context_set_font(imfont);
+
+   if (note.color.n != 0)
+      imlib_context_set_color(note.color.r,
+                              note.color.g,
+                              note.color.b,
+                              note.color.a);
+
+   imlib_text_draw(note.x, note.y, note.text);
+}
+
+void load_font(void)
+{
+   const size_t len = strlen(note.font) + 1 + 3;
+   char *fontname = malloc(len);
+
+   snprintf(fontname, len, "%s/%d", note.font, note.size);
+
+   imlib_add_path_to_font_path("/usr/share/fonts/TTF");
+
+   imfont = imlib_load_font(fontname);
+
+   if (!imfont) {
+      scrot_note_free();
+      fprintf(stderr, "Failed to load fontname: %s\n", fontname);
+      exit(EXIT_FAILURE);
+   }
+}

--- a/src/note.c
+++ b/src/note.c
@@ -98,7 +98,10 @@ malformed:
            exit(EXIT_FAILURE);
         }
 
-        options_parse_required_number(++number);
+        int fntsize = options_parse_required_number(++number);
+
+        if (fntsize < 6)
+           fprintf(stderr, "Warning: --note option: font size < 6\n");
      }
      break;
      case 'x': {

--- a/src/note.h
+++ b/src/note.h
@@ -53,6 +53,7 @@ struct __scrotnote
    char *text;    /* text of the note            */
    int x;         /* position screen (optional)  */
    int y;         /* position screen (optional)  */
+   double angle;  /* angle text (optional)       */
 
    struct color   /*                 (optional)  */
    {

--- a/src/note.h
+++ b/src/note.h
@@ -1,0 +1,74 @@
+/* note.h
+
+Copyright 2019  Daniel T. Borelli <danieltborelli@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+ 
+#ifndef NOTE_H
+#define NOTE_H
+
+#include "options.h"
+
+/*
+ * Format: f=STRING/NUM:x=NUM:y=NUM:t:STRING:c=NUM,NUM,NUM,NUM
+ *
+ * f= fontname/size
+ * x= screen position x
+ * y= screen position y
+ * t= string note
+ * c= color(red,green,blue,alpha) range 0..255
+ *
+ * */
+
+struct __scrotnote
+{
+   char *font;    /* font name         */
+   char *text;    /* text of the note  */
+   int size;      /* font size         */
+   int x;         /* position screen   */
+   int y;         /* position screen   */
+
+   struct color   /* optional          */
+   {
+      int n;      /* counter colors found
+                   * -1 == error parser
+                   *  0 == the user did not indicate the color
+                   * */
+
+      int r,      /* red               */
+          g,      /* green             */
+          b,      /* blue              */
+          a;      /* alpha             */
+   } color;
+};
+
+extern scrotnote note;
+
+void scrot_note_new(char *format);
+
+void scrot_note_free(void);
+
+void scrot_note_draw(Imlib_Image im);
+
+#endif

--- a/src/note.h
+++ b/src/note.h
@@ -31,34 +31,36 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "options.h"
 
 /*
- * Format: -f STRING/NUM -x NUM -y NUM -t 'STRING' -c NUM,NUM,NUM,NUM
+ * Format: -f 'NAME/SIZE' -x NUM -y NUM -t 'TEXT' -c NUM,NUM,NUM,NUM
  *
- * f= fontname/size
- * x= screen position x
- * y= screen position y
- * t= string note
- * c= color(red,green,blue,alpha) range 0..255
+ * -f fontname/size - absolute path
+ * -x screen position x
+ * -y screen position y
+ * -t text note
+ * -c color(red,green,blue,alpha) range 0..255
  *
  * */
 
+enum ecolor {
+   COLOR_ERROR    = -1, /* error parser                        */
+   COLOR_OPTIONAL = 0,  /* the user did not indicate the color */
+   COLOR_OK       = 1,  /* the user indicate the color         */
+};
+
 struct __scrotnote
 {
-   char *font;    /* font name         */
-   char *text;    /* text of the note  */
-   int x;         /* position screen   */
-   int y;         /* position screen   */
+   char *font;    /* font name                   */
+   char *text;    /* text of the note            */
+   int x;         /* position screen (optional)  */
+   int y;         /* position screen (optional)  */
 
-   struct color   /* optional          */
+   struct color   /*                 (optional)  */
    {
-      int n;      /* counter colors found
-                   * -1 == error parser
-                   *  0 == the user did not indicate the color
-                   * */
-
-      int r,      /* red               */
-          g,      /* green             */
-          b,      /* blue              */
-          a;      /* alpha             */
+      enum ecolor status;
+      int r,                  /* red             */
+          g,                  /* green           */
+          b,                  /* blue            */
+          a;                  /* alpha           */
    } color;
 };
 

--- a/src/note.h
+++ b/src/note.h
@@ -31,7 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "options.h"
 
 /*
- * Format: f=STRING/NUM:x=NUM:y=NUM:t:STRING:c=NUM,NUM,NUM,NUM
+ * Format: -f STRING/NUM -x NUM -y NUM -t 'STRING' -c NUM,NUM,NUM,NUM
  *
  * f= fontname/size
  * x= screen position x
@@ -45,7 +45,6 @@ struct __scrotnote
 {
    char *font;    /* font name         */
    char *text;    /* text of the note  */
-   int size;      /* font size         */
    int x;         /* position screen   */
    int y;         /* position screen   */
 

--- a/src/options.c
+++ b/src/options.c
@@ -289,7 +289,12 @@ void options_parse_note(char *optarg)
 {
    opt.note = gib_estrdup(optarg);
 
-   if(opt.note == NULL) return;
+   if (opt.note == NULL) return;
+
+   if (opt.note[0] == '\0') {
+      fprintf(stderr, "Required arguments for --note.");
+      exit(EXIT_FAILURE);
+   }
 
    scrot_note_new(opt.note);
 }

--- a/src/options.c
+++ b/src/options.c
@@ -416,6 +416,8 @@ show_usage(void)
            "  -o, --overwrite           By default " SCROT_PACKAGE " does not overwrite the files, use this option to allow it.\n"
            "  -l, --line                Indicates the style of the line when the selection is used: --select\n"
            "                            See SELECTION STYLE\n"
+           "  -n, --note                Draw a text note.\n"
+           "                            See NOTE FORMAT\n"
 
            "\n" "  SPECIAL STRINGS\n"
            "  Both the --exec and filename parameters can take format specifiers\n"
@@ -448,7 +450,16 @@ show_usage(void)
            "  The default style are:\n"
            "                  style=solid,width=1\n"
            "  Example:\n" "          " SCROT_PACKAGE
-           "  --line style=dash,width=3 --select\n\n"
+           " --line style=dash,width=3 --select\n\n"
+           "\n" "  NOTE FORMAT\n"
+           "  The following specifiers are recognised for the option --note\n"
+           "                  -f 'FontName/size'\n"
+           "                  -t 'text'\n"
+           "                  -x position (optional)\n"
+           "                  -y position (optional)\n"
+           "                  -c color(RGBA) (optional)\n"
+           "  Example:\n" "          " SCROT_PACKAGE
+           " --note \"-f '/usr/share/fonts/TTF/DroidSans-Bold/40' -x 10 -y 20 -c 255,0,0,255 -t 'Hi'\"\n\n"
            "This program is free software see the file COPYING for licensing info.\n"
            "Copyright Tom Gilbert 2000\n"
            "Email bugs to <scrot_sucks@linuxbrit.co.uk>\n");

--- a/src/options.c
+++ b/src/options.c
@@ -51,8 +51,8 @@ init_parse_options(int argc, char **argv)
    scrot_parse_option_array(argc, argv);
 }
 
-static int
-parse_option_required_number(char *str)
+int
+options_parse_required_number(char *str)
 {
    char *end = NULL;
    int ret = 0;
@@ -78,7 +78,7 @@ parse_option_required_number(char *str)
 static void
 scrot_parse_option_array(int argc, char **argv)
 {
-   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:z";
+   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zn:";
    static struct option lopts[] = {
       /* actions */
       {"help", 0, 0, 'h'},                  /* okay */
@@ -100,6 +100,7 @@ scrot_parse_option_array(int argc, char **argv)
       {"exec", 1, 0, 'e'},
       {"debug-level", 1, 0, '+'},
       {"autoselect", required_argument, 0, 'a'},
+      {"note", required_argument, 0, 'n'},
       {0, 0, 0, 0}
    };
    int optch = 0, cmdx = 0;
@@ -122,7 +123,7 @@ scrot_parse_option_array(int argc, char **argv)
            opt.border = 1;
            break;
         case 'd':
-           opt.delay = parse_option_required_number(optarg);
+           opt.delay = options_parse_required_number(optarg);
            break;
         case 'e':
            opt.exec = gib_estrdup(optarg);
@@ -131,7 +132,7 @@ scrot_parse_option_array(int argc, char **argv)
            opt.multidisp = 1;
            break;
         case 'q':
-           opt.quality = parse_option_required_number(optarg);
+           opt.quality = options_parse_required_number(optarg);
            break;
         case 's':
            opt.select = 1;
@@ -140,7 +141,7 @@ scrot_parse_option_array(int argc, char **argv)
            opt.focused = 1;
            break;
         case '+':
-           opt.debug_level = parse_option_required_number(optarg);
+           opt.debug_level = options_parse_required_number(optarg);
            break;
         case 'c':
            opt.countdown = 1;
@@ -162,6 +163,9 @@ scrot_parse_option_array(int argc, char **argv)
            break;
         case 'a':
            options_parse_autoselect(optarg);
+           break;
+        case 'n':
+           options_parse_note(optarg);
            break;
         case '?':
            exit(EXIT_FAILURE);
@@ -234,9 +238,9 @@ options_parse_autoselect(char *optarg)
 
    if (strchr(optarg, ',')) /* geometry dimensions must be in format x,y,w,h   */
    {
-     dimensions[i++] = parse_option_required_number(strtok(optarg, tokdelim));
+     dimensions[i++] = options_parse_required_number(strtok(optarg, tokdelim));
      while ((tok = strtok(NULL, tokdelim)) )
-        dimensions[i++] = parse_option_required_number(tok);
+        dimensions[i++] = options_parse_required_number(tok);
      opt.autoselect=1;
      opt.autoselect_x=dimensions[0];
      opt.autoselect_y=dimensions[1];
@@ -253,12 +257,12 @@ options_parse_thumbnail(char *optarg)
    if (strchr(optarg, 'x')) /* We want to specify the geometry */
    {
      tok = strtok(optarg, "x");
-     opt.thumb_width = parse_option_required_number(tok);
+     opt.thumb_width = options_parse_required_number(tok);
      tok = strtok(NULL, "x");
      if (tok)
      {
-       opt.thumb_width = parse_option_required_number(optarg);
-       opt.thumb_height = parse_option_required_number(tok);
+       opt.thumb_width = options_parse_required_number(optarg);
+       opt.thumb_height = options_parse_required_number(tok);
 
        if (opt.thumb_width < 0)
          opt.thumb_width = 1;
@@ -273,12 +277,21 @@ options_parse_thumbnail(char *optarg)
    }
    else
    {
-     opt.thumb = parse_option_required_number(optarg);
+     opt.thumb = options_parse_required_number(optarg);
      if (opt.thumb < 1)
        opt.thumb = 1;
      else if (opt.thumb > 100)
        opt.thumb = 100;
    }
+}
+
+void options_parse_note(char *optarg)
+{
+   opt.note = gib_estrdup(optarg);
+
+   if(opt.note == NULL) return;
+
+   scrot_note_new(opt.note);
 }
 
 void

--- a/src/options.h
+++ b/src/options.h
@@ -53,6 +53,7 @@ struct __scrotoptions
    char *output_file;
    char *thumb_file;
    char *exec;
+   char *note;
    int autoselect;
    int autoselect_x;
    int autoselect_y;
@@ -64,6 +65,8 @@ void init_parse_options(int argc, char **argv);
 char *name_thumbnail(char *name);
 void options_parse_thumbnail(char *optarg);
 void options_parse_autoselect(char *optarg);
+void options_parse_note(char *optarg);
+int  options_parse_required_number(char *str);
 extern scrotoptions opt;
 
 #endif

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -62,6 +62,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "structs.h"
 #include "getopt.h"
 #include "debug.h"
+#include "note.h"
 
 #ifndef __GNUC__
 # define __attribute__(x)

--- a/src/structs.h
+++ b/src/structs.h
@@ -27,5 +27,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define STRUCTS_H
 
 typedef struct __scrotoptions scrotoptions;
+typedef struct __scrotnote scrotnote;
 
 #endif


### PR DESCRIPTION
Alpha testing.

New option: `-n` or `--note`

```bash
./scrot -n "-f '/usr/share/fonts/TTF/DejaVuSans-Bold/30' -x 10 -y 20 -t 'test color with alpha' -c 232,91,44,150" -s

 -f 'font_name/size' (Imlib2 API)
 -t 'text'
 -x position x (optional)
 -y position y (optional)
 -c color r,g,b,a (optional)
```
![color_note](https://user-images.githubusercontent.com/46515895/59284740-2a300b80-8c43-11e9-8548-b92dedbfdc26.png)
TODO:

- [x]  manpage
- [x]  color text
~~- [ ] background color, draw rectangle~~
- [x] orientation: ~~left,up,down,right~~ **angle**
- [x] user define font path. requirement

![scrot_angle](https://user-images.githubusercontent.com/46515895/60060736-7b6edf00-96c8-11e9-9e42-1ebef47786b9.png)
