### PR TITLE
adds option to embed hostname in output file name

### DIFF
--- a/man/scrot.1
+++ b/man/scrot.1
@@ -114,6 +114,7 @@ following specifiers are recognised:
 .PP
 .nf
 .fam C
+    $a  hostname
     $f  image path/filename (ignored when used in the filename)
     $m  thumb image path/filename (ignored when used in the filename)
     $n  image name (ignored when used in the filename)

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -51,6 +51,7 @@ SPECIAL STRINGS
   time. The second kind are internal to scrot and are prefixed by '$' The
   following specifiers are recognised:
 
+    $a  hostname
     $f  image path/filename (ignored when used in the filename)
     $m  thumb image path/filename (ignored when used in the filename)
     $n  image name (ignored when used in the filename)

--- a/src/main.c
+++ b/src/main.c
@@ -621,6 +621,10 @@ im_printf(char *str, struct tm *tm,
     if (*c == '$') {
       c++;
       switch (*c) {
+        case 'a':
+          gethostname(buf, sizeof(buf));
+          strcat(ret, buf);
+          break;
         case 'f':
           if (filename_im)
             strcat(ret, filename_im);

--- a/src/options.c
+++ b/src/options.c
@@ -338,6 +338,7 @@ show_usage(void)
            "  The second kind are internal to " SCROT_PACKAGE
            "  and are prefixed by '$'\n"
            "  The following specifiers are recognised:\n"
+           "                  $a hostname\n"
            "                  $f image path/filename (ignored when used in the filename)\n"
            "                  $m thumbnail path/filename\n"
            "                  $n image name (ignored when used in the filename)\n"


### PR DESCRIPTION
I move between multiple computers and save screenshots to a folder that is synchronized between them with Syncthing. This is handy when I'm writing documentation on one computer and taking screenshots of whatever I'm documenting on the other. 
Problem: how to tell which screenshot came from what system?

This PR adds a `$a` format flag that adds the system's hostname to the file name.

I picked "a" because hostnAme (h and n were already in use).