### PR TITLE
New option: --line, selection line style

### DIFF
--- a/man/scrot.1
+++ b/man/scrot.1
@@ -101,10 +101,13 @@ Freeze the screen when the selection is used: \fB--select\fP
 .B
 \fB-o\fP, \fB--overwrite\fP
 By default \fBscrot\fP does not overwrite the files, use this option to allow it.
-.RE
-.PP
-
+.TP
+.B
+\fB-l\fP, \fB--line\fP
+Indicates the style of the line when the selection is used: \fB--select\fP
+See SELECTION STYLE
 .SH SPECIAL STRINGS
+
 Both the \fB--exec\fP and filename parameters can take format specifiers that are
 expanded by \fBscrot\fP when encountered. There are two types of format specifier.
 Characters preceded by a '%' are interpreted by \fBstrftime\fP(2). See man strftime
@@ -133,6 +136,28 @@ following specifiers are recognised:
 \fBscrot\fP '%Y-%m-%d_$wx$h.png' \fB-e\fP 'mv $f ~/shots/'
 This would create a \fIfile\fP called something like 2000-10-30_2560x1024.png
 and move it to your shots directory.
+.RE
+.PP
+
+.SH SELECTION STYLE
+
+When using \fB--select\fP you can indicate the style of the line with \fB--line\fP.
+.PP
+The following specifiers are recognised:
+.PP
+.nf
+.fam C
+                  style=(solid,dash),width=(range 1 to 8)
+
+.fam T
+.fi
+The default style are:
+style=solid,width=1
+.SH EXAMPLE
+.TP
+.B
+\fBscrot\fP
+\fB--line\fP style=dash,width=3 \fB--select\fP
 .SH AUTHOR
 \fBscrot\fP was originally developed by Tom Gilbert under MIT-advertising license.
 .PP

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -41,9 +41,11 @@ OPTIONS
   -p, --pointer      Capture the mouse pointer.
   -f, --freeze       Freeze the screen when the selection is used: --select
   -o, --overwrite    By default scrot does not overwrite the files, use this option to allow it.
-
+  -l, --line         Indicates the style of the line when the selection is used: --select
+                     See SELECTION STYLE
 
 SPECIAL STRINGS
+
   Both the --exec and filename parameters can take format specifiers that are
   expanded by scrot when encountered. There are two types of format specifier.
   Characters preceded by a '%' are interpreted by strftime(2). See man strftime
@@ -66,6 +68,20 @@ EXAMPLE
   scrot '%Y-%m-%d_$wx$h.png' -e 'mv $f ~/shots/'  
        This would create a file called something like 2000-10-30_2560x1024.png
        and move it to your shots directory.
+
+
+SELECTION STYLE
+
+  When using --select you can indicate the style of the line with --line.
+
+  The following specifiers are recognised:
+
+                  style=(solid,dash),width=(range 1 to 8)
+
+  The default style are:
+                  style=solid,width=1
+EXAMPLE
+ scrot  --line style=dash,width=3 --select
 
 AUTHOR
   scrot was originally developed by Tom Gilbert under MIT-advertising license.

--- a/src/main.c
+++ b/src/main.c
@@ -356,6 +356,8 @@ scrot_sel_and_grab_image(void)
               GCFunction | GCForeground | GCBackground | GCSubwindowMode,
               &gcval);
 
+  XSetLineAttributes(disp, gc, opt.line_width, opt.line_style, CapRound, JoinRound);
+
   if ((XGrabPointer
        (disp, root, False,
         ButtonMotionMask | ButtonPressMask | ButtonReleaseMask, GrabModeAsync,

--- a/src/options.c
+++ b/src/options.c
@@ -46,6 +46,8 @@ init_parse_options(int argc, char **argv)
 
    opt.quality = 75;
    opt.overwrite = 0;
+   opt.line_style = LineSolid;
+   opt.line_width = 1;
 
    /* Parse the cmdline args */
    scrot_parse_option_array(argc, argv);
@@ -73,12 +75,73 @@ parse_option_required_number(char *str)
    return ret;
 }
 
+static void
+options_parse_line(char *optarg)
+{
+   enum {STYLE = 0, WIDTH };
+
+   char *const token[] = {
+      [STYLE] = "style",
+      [WIDTH] = "width",
+      NULL
+   };
+
+   char *subopts = optarg;
+   char *value = NULL;
+
+   while (*subopts != '\0') {
+      switch(getsubopt(&subopts, token, &value)) {
+
+         case STYLE:
+
+            if (value == NULL) {
+               fprintf(stderr, "Missing value for "
+                     "suboption '%s'\n", token[STYLE]);
+               exit(EXIT_FAILURE);
+            }
+
+            if (!strncmp(value, "dash", 4))
+               opt.line_style = LineOnOffDash;
+            else if (!strncmp(value, "solid", 5))
+               opt.line_style = LineSolid;
+            else {
+               fprintf(stderr, "Unknown value for "
+                     "suboption '%s': %s\n", token[STYLE], value);
+               exit(EXIT_FAILURE);
+            }
+            break;
+
+         case WIDTH:
+
+            if (value == NULL) {
+               fprintf(stderr, "Missing value for "
+                     "suboption '%s'\n", token[WIDTH]);
+               exit(EXIT_FAILURE);
+            }
+
+            opt.line_width = parse_option_required_number(value);
+
+            if (opt.line_width <= 0 || opt.line_width > 8){
+               fprintf(stderr, "Value of the range (1..8) for "
+                     "suboption '%s': %d\n", token[WIDTH], opt.line_width);
+               exit(EXIT_FAILURE);
+            }
+            break;
+
+         default:
+            fprintf(stderr, "No match found for token: '%s'\n", value);
+            exit(EXIT_FAILURE);
+            break;
+      }
+
+   } /* while */
+}
 
 
 static void
 scrot_parse_option_array(int argc, char **argv)
 {
-   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:z";
+   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zl:";
    static struct option lopts[] = {
       /* actions */
       {"help", 0, 0, 'h'},                  /* okay */
@@ -100,6 +163,7 @@ scrot_parse_option_array(int argc, char **argv)
       {"exec", 1, 0, 'e'},
       {"debug-level", 1, 0, '+'},
       {"autoselect", required_argument, 0, 'a'},
+      {"line", required_argument, 0, 'l'},
       {0, 0, 0, 0}
    };
    int optch = 0, cmdx = 0;
@@ -162,6 +226,9 @@ scrot_parse_option_array(int argc, char **argv)
            break;
         case 'a':
            options_parse_autoselect(optarg);
+           break;
+        case 'l':
+           options_parse_line(optarg);
            break;
         case '?':
            exit(EXIT_FAILURE);
@@ -328,6 +395,8 @@ show_usage(void)
            "  -p, --pointer             Capture the mouse pointer.\n"
            "  -f, --freeze              Freeze the screen when the selection is used: --select\n"
            "  -o, --overwrite           By default " SCROT_PACKAGE " does not overwrite the files, use this option to allow it.\n"
+           "  -l, --line                Indicates the style of the line when the selection is used: --select\n"
+           "                            See SELECTION STYLE\n"
 
            "\n" "  SPECIAL STRINGS\n"
            "  Both the --exec and filename parameters can take format specifiers\n"
@@ -352,6 +421,14 @@ show_usage(void)
            " '%%Y-%%m-%%d_$wx$h_scrot.png' -e 'mv $f ~/images/shots/'\n"
            "          Creates a file called something like 2000-10-30_2560x1024_scrot.png\n"
            "          and moves it to your images directory.\n" "\n"
+           "\n" "  SELECTION STYLE\n"
+           "  When using --select you can indicate the style of the line with --line.\n"
+           "  The following specifiers are recognised:\n"
+           "                  style=(solid,dash),width=(range 1 to 8)\n"
+           "  The default style are:\n"
+           "                  style=solid,width=1\n"
+           "  Example:\n" "          " SCROT_PACKAGE
+           "  --line style=dash,width=3 --select\n\n"
            "This program is free software see the file COPYING for licensing info.\n"
            "Copyright Tom Gilbert 2000\n"
            "Email bugs to <scrot_sucks@linuxbrit.co.uk>\n");

--- a/src/options.h
+++ b/src/options.h
@@ -50,6 +50,8 @@ struct __scrotoptions
    int pointer;
    int freeze;
    int overwrite;
+   int line_style;
+   int line_width;
    char *output_file;
    char *thumb_file;
    char *exec;


### PR DESCRIPTION
This new option allows us to define the type of line and its width.
Examples:
```bash
scrot  --select --line style=dash

scrot --select --line width=3

scrot --select --line style=dash,width=3
```
Note: use `getsubopt (glibc >= 2.12)` which is available since 2010 so I do not think we should verify this version with autotool.