### PR TITLE
adds gitignore for to ignore autogenerated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ src/Makefile
 src/config.h
 src/scrot_config.h
 src/stamp-h1
-
+src/*.o
+src/scrot

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+*.in
+aclocal.m4
+autom4te.cache
+compile
+configure
+depcomp
+install-sh
+missing
+Makefile
+config.*
+src/.deps
+src/Makefile
+src/config.h
+src/scrot_config.h
+src/stamp-h1
+


### PR DESCRIPTION
This PR adds a `.gitignore` file to reduce risk of accidentally committing auto-generated files.