### PR TITLE
Fix warnings in getopt.c

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -76,6 +76,8 @@
 #endif
 #endif
 
+#include <string.h>
+
 #ifndef _
 /* This is for other GNU distributions with internationalized messages.
    When compiling libc, the _ macro is predefined.  */

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -694,6 +694,7 @@ _getopt_internal(argc, argv, optstring, longopts, longind, long_only)
             else
             {
                if (opterr)
+               {
                   if (argv[optind - 1][1] == '-')
                      /* --option */
                      fprintf(stderr,
@@ -706,7 +707,7 @@ _getopt_internal(argc, argv, optstring, longopts, longind, long_only)
                              _
                              ("%s: option `%c%s' doesn't allow an argument\n"),
                              argv[0], argv[optind - 1][0], pfound->name);
-
+	       }
                nextchar += strlen(nextchar);
 
                optopt = pfound->val;


### PR DESCRIPTION
The patches applied to pkgsrc to fix the warnings in `getopt.c` is shared here.

1. Fix the missing `string.h` when building in NetBSD

    It seems `string.h` was conditionally included and was causing the compiler to spit out warnings. `string.h` is now unconditionally included to prevent this issues.

2. Fix the ambiguous `else` for the `if` in line 689

    This has been fixed by adding the correct braces to the `if` condition in line 689.

This pull request addresses #26 in the issue tracker. 