### PR TITLE
Fix GCC >=8.0 warning: -Wstringop-truncation 

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -700,8 +700,11 @@ im_printf(char *str, struct tm *tm,
           strncat(ret, c, 1);
           break;
       }
-    } else
-      strncat(ret, c, 1);
+    } else {
+      const size_t len = strlen(ret);
+      ret[len] = *c;
+      ret[len + 1] = '\0';
+    }
   }
   return gib_estrdup(ret);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -623,7 +623,11 @@ im_printf(char *str, struct tm *tm,
   struct stat st;
 
   ret[0] = '\0';
-  strftime(strf, 4095, str, tm);
+
+  if (strftime(strf, 4095, str, tm) == 0) {
+    fprintf(stderr, "strftime returned 0\n");
+    exit(EXIT_FAILURE);
+  }
 
   for (c = strf; *c != '\0'; c++) {
     if (*c == '$') {


### PR DESCRIPTION
Hi,
This PR fix #28 
The new version of `GCC >=8.0` includes the `-Wstringop-truncation` flag.
This flag alerts the possibility that a string ends without the null character.
When variable `*c` is not equal to the characters `$` or `\` then the compiler cannot know if the next character is null and therefore throws the warning.
I opted to manually concatenate the buffer.
@eribertomota merge it whenever you want.

