### PR TITLE
Add Display Option.

### DIFF
--- a/man/scrot.1
+++ b/man/scrot.1
@@ -42,6 +42,10 @@ Display help output and exit.
 Output version information and exit.
 .TP
 .B
+\fB-D\fP, \fB--display\fP
+Specify the display to use; see X(7).
+.TP
+.B
 \fB-a\fP, \fB--autoselect\fP
 Non-interactively choose a rectangle of x,y,w,h.
 .TP

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -22,6 +22,7 @@ DESCRIPTION
 OPTIONS
   -h, --help         Display help output and exit.
   -v, --version      Output version information and exit.
+  -D, --display      specify the display to use; see X(7).
   -a, --autoselect   Non-interactively choose a rectangle of x,y,w,h.
   -b, --border       When selecting a window, grab wm border too.
   -c, --count        Display a countdown when used with delay.

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -38,7 +38,9 @@ init_x_and_imlib(char *dispstr, int screen_num)
 {
    disp = XOpenDisplay(dispstr);
    if (!disp) {
-      fprintf(stderr, "Can't open X display. It *is* running, yeah?");
+      fprintf(stderr, "Can't open X display. It *is* running, yeah? [");
+      fprintf(stderr, dispstr);
+      fprintf(stderr, "]");
       exit(EXIT_FAILURE);
    }
 

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -39,7 +39,7 @@ init_x_and_imlib(char *dispstr, int screen_num)
    disp = XOpenDisplay(dispstr);
    if (!disp) {
       fprintf(stderr, "Can't open X display. It *is* running, yeah? [");
-      fprintf(stderr, dispstr);
+      fprintf(stderr, "%s", dispstr);
       fprintf(stderr, "]");
       exit(EXIT_FAILURE);
    }

--- a/src/main.c
+++ b/src/main.c
@@ -49,7 +49,7 @@ main(int argc,
 
   init_parse_options(argc, argv);
 
-  init_x_and_imlib(NULL, 0);
+  init_x_and_imlib(opt.display, 0);
 
   if (!opt.output_file) {
     opt.output_file = gib_estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");

--- a/src/options.c
+++ b/src/options.c
@@ -50,6 +50,7 @@ init_parse_options(int argc, char **argv)
    opt.line_style = LineSolid;
    opt.line_width = 1;
    opt.line_color = NULL;
+   opt.display = NULL;
 
    /* Parse the cmdline args */
    scrot_parse_option_array(argc, argv);
@@ -155,7 +156,7 @@ options_parse_line(char *optarg)
 static void
 scrot_parse_option_array(int argc, char **argv)
 {
-   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zn:l:";
+   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zn:l:D:";
 
    static struct option lopts[] = {
       /* actions */
@@ -178,6 +179,7 @@ scrot_parse_option_array(int argc, char **argv)
       {"exec", 1, 0, 'e'},
       {"debug-level", 1, 0, '+'},
       {"autoselect", required_argument, 0, 'a'},
+      {"display", required_argument, 0, 'D'},
       {"note", required_argument, 0, 'n'},
       {"line", required_argument, 0, 'l'},
       {0, 0, 0, 0}
@@ -242,6 +244,9 @@ scrot_parse_option_array(int argc, char **argv)
            break;
         case 'a':
            options_parse_autoselect(optarg);
+           break;
+        case 'D':
+           options_parse_display(optarg);
            break;
         case 'n':
            options_parse_note(optarg);
@@ -332,6 +337,21 @@ options_parse_autoselect(char *optarg)
 }
 
 void
+options_parse_display(char *optarg)
+{
+   size_t length = 0;
+   char *new_display;
+
+   length = strlen(optarg) + 1;
+   if (length > 256) {
+     length = 256;
+   }
+   new_display = gib_emalloc(length);
+   strncpy(new_display, optarg, length);
+   opt.display=new_display;
+}
+
+void
 options_parse_thumbnail(char *optarg)
 {
    char *tok;
@@ -407,6 +427,7 @@ show_usage(void)
            "  current directory.\n" "  See man " SCROT_PACKAGE " for more details\n"
            "  -h, --help                display this help and exit\n"
            "  -v, --version             output version information and exit\n"
+           "  -D, --display             Set DISPLAY target other than current\n"
            "  -a, --autoselect          non-interactively choose a rectangle of x,y,w,h\n"
            "  -b, --border              When selecting a window, grab wm border too\n"
            "  -c, --count               show a countdown before taking the shot\n"

--- a/src/options.h
+++ b/src/options.h
@@ -56,6 +56,7 @@ struct __scrotoptions
    char *output_file;
    char *thumb_file;
    char *exec;
+   char *display;
    char *note;
    int autoselect;
    int autoselect_x;
@@ -68,6 +69,7 @@ void init_parse_options(int argc, char **argv);
 char *name_thumbnail(char *name);
 void options_parse_thumbnail(char *optarg);
 void options_parse_autoselect(char *optarg);
+void options_parse_display(char *optarg);
 void options_parse_note(char *optarg);
 int  options_parse_required_number(char *str);
 extern scrotoptions opt;


### PR DESCRIPTION
Adds option  _-D_, _--display_ and mirrors other display arguments in common X programs e.g. _xeyes_.

This is good for scripting and other monitoring when using _ssh_ or _screen_ and the **DISPLAY** environment variable is not set.