### PR TITLE
Issue#36 Fix visual artifacts in screen: option --select

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -36,7 +36,6 @@ OPTIONS
                      See -l and -f options.
   -l, --line         Indicates the style of the line when the -s option is used.
                      See SELECTION STYLE.
-  -f, --freeze       Freeze the screen when the -s option is used.
   -u, --focused      Use the currently focused window.
   -t, --thumb NUM|GEOM  Generate thumbnail too. NUM is the percentage of the
                         original size for the thumbnail to be. Alternatively,
@@ -79,11 +78,11 @@ SELECTION STYLE
 
   The following specifiers are recognised:
 
-    style=(solid,dash),width=(range 1 to 8),color="value"
+    width=(range 1 to 8),color="value"
 
   The default style is:
 
-    style=solid,width=1
+    color="gray",width=1
 
   For the color you can use a name or a hexdecimal value.
 
@@ -91,7 +90,7 @@ SELECTION STYLE
 
   Example:
 
-    scrot --line style=dash,width=3,color="red" --select
+    scrot --line width=3,color="red" --select
 
 NOTE FORMAT
   The following specifiers are recognised for the option --note:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,4 +34,4 @@ LIBOBJS = @LIBOBJS@
 bin_PROGRAMS      = scrot
 scrot_SOURCES       = main.c getopt.c getopt1.c getopt.h scrot.h \
 options.c options.h debug.h imlib.c structs.h note.c note.h
-scrot_LDADD         = -lX11 -lXfixes -lXcursor @GIBLIB_LIBS@
+scrot_LDADD         = -lX11 -lXfixes -lXcursor -lXext @GIBLIB_LIBS@

--- a/src/options.c
+++ b/src/options.c
@@ -47,9 +47,8 @@ init_parse_options(int argc, char **argv)
 
    opt.quality = 75;
    opt.overwrite = 0;
-   opt.line_style = LineSolid;
    opt.line_width = 1;
-   opt.line_color = NULL;
+   opt.line_color = "gray";
 
    /* Parse the cmdline args */
    scrot_parse_option_array(argc, argv);
@@ -80,10 +79,9 @@ options_parse_required_number(char *str)
 static void
 options_parse_line(char *optarg)
 {
-   enum {STYLE = 0, WIDTH, COLOR };
+   enum {WIDTH=0, COLOR };
 
    char *const token[] = {
-      [STYLE] = "style",
       [WIDTH] = "width",
       [COLOR] = "color",
       NULL
@@ -94,26 +92,6 @@ options_parse_line(char *optarg)
 
    while (*subopts != '\0') {
       switch(getsubopt(&subopts, token, &value)) {
-
-         case STYLE:
-
-            if (value == NULL) {
-               fprintf(stderr, "Missing value for "
-                     "suboption '%s'\n", token[STYLE]);
-               exit(EXIT_FAILURE);
-            }
-
-            if (!strncmp(value, "dash", 4))
-               opt.line_style = LineOnOffDash;
-            else if (!strncmp(value, "solid", 5))
-               opt.line_style = LineSolid;
-            else {
-               fprintf(stderr, "Unknown value for "
-                     "suboption '%s': %s\n", token[STYLE], value);
-               exit(EXIT_FAILURE);
-            }
-            break;
-
          case WIDTH:
 
             if (value == NULL) {
@@ -155,7 +133,7 @@ options_parse_line(char *optarg)
 static void
 scrot_parse_option_array(int argc, char **argv)
 {
-   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zn:l:";
+   static char stropts[] = "a:opbcd:e:hmq:st:uv+:zn:l:";
 
    static struct option lopts[] = {
       /* actions */
@@ -169,7 +147,6 @@ scrot_parse_option_array(int argc, char **argv)
       {"multidisp", 0, 0, 'm'},
       {"silent", 0, 0, 'z'},
       {"pointer", 0, 0, 'p'},
-      {"freeze", 0, 0, 'f'},
       {"overwrite", 0, 0, 'o'},
       /* toggles */
       {"thumb", 1, 0, 't'},
@@ -233,9 +210,6 @@ scrot_parse_option_array(int argc, char **argv)
            break;
         case 'p':
            opt.pointer = 1;
-           break;
-        case 'f':
-           opt.freeze = 1;
            break;
         case 'o':
            opt.overwrite = 1;
@@ -426,7 +400,6 @@ show_usage(void)
            "                            or the geometry in percent, e.g. 50x60 or 80x20.\n"
            "  -z, --silent              Prevent beeping\n"
            "  -p, --pointer             Capture the mouse pointer.\n"
-           "  -f, --freeze              Freeze the screen when the selection is used: --select\n"
            "  -o, --overwrite           By default " SCROT_PACKAGE " does not overwrite the files, use this option to allow it.\n"
            "  -l, --line                Indicates the style of the line when the selection is used: --select\n"
            "                            See SELECTION STYLE\n"
@@ -460,13 +433,13 @@ show_usage(void)
            "\n" "  SELECTION STYLE\n"
            "  When using --select you can indicate the style of the line with --line.\n"
            "  The following specifiers are recognised:\n"
-           "                  style=(solid,dash),width=(range 1 to 8),color=\"value\"\n"
-           "  The default style are:\n"
-           "                  style=solid,width=1\n"
+           "                  width=(range 1 to 8),color=\"value\"\n"
            "  For the color you can use a name or a hexdecimal value.\n"
            "                  color=\"red\" or color=\"#ff0000\"\n"
+           "  The default style are:\n"
+           "                  color=\"gray\",width=1\n"
            "  Example:\n" "          " SCROT_PACKAGE
-           " --line style=dash,width=3,color=\"red\" --select\n\n"
+           " --line width=3,color=\"red\" --select\n\n"
            "\n" "  NOTE FORMAT\n"
            "  The following specifiers are recognised for the option --note\n"
            "                  -f 'FontName/size'\n"

--- a/src/options.h
+++ b/src/options.h
@@ -42,15 +42,13 @@ struct __scrotoptions
    int focused;
    int quality;
    int border;
-   int silent;   
+   int silent;
    int multidisp;
    int thumb;
    int thumb_width;
    int thumb_height;
    int pointer;
-   int freeze;
    int overwrite;
-   int line_style;
    int line_width;
    char *line_color;
    char *output_file;

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -38,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xresource.h>
 #include <X11/cursorfont.h>
 #include <X11/extensions/Xfixes.h>
+#include <X11/extensions/shape.h>
 #include <X11/Xcursor/Xcursor.h>
 
 #include <stdio.h>


### PR DESCRIPTION
The` --freeze` option is no longer used.

The `--line style=` option is no longer used.
It is still supporting the others, `color` and `width`.
`scrot -s -l color=red,with=4`

We need to test it in different window managers, with and without composition.

