### PR TITLE
Fix issue#39

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -64,7 +64,7 @@ main(int argc,
   else if (opt.select)
     image = scrot_sel_and_grab_image();
   else if (opt.autoselect)
-    image = gib_imlib_create_image_from_drawable(root, 0, opt.autoselect_x, opt.autoselect_y, opt.autoselect_w, opt.autoselect_h, 1);
+    image = scrot_grab_autoselect();
   else
   {
     scrot_do_delay();
@@ -525,6 +525,20 @@ scrot_sel_and_grab_image(void)
     if (opt.pointer == 1)
        scrot_grab_mouse_pointer(im, rx, ry);
   }
+  return im;
+}
+
+Imlib_Image
+scrot_grab_autoselect(void)
+{
+  Imlib_Image im = NULL;
+  int rx = opt.autoselect_x, ry = opt.autoselect_y, rw = opt.autoselect_w, rh = opt.autoselect_h;
+  Window target = None;
+
+  scrot_nice_clip(&rx, &ry, &rw, &rh);
+  im = gib_imlib_create_image_from_drawable(root, 0, rx, ry, rw, rh, 1);
+  if (opt.pointer == 1)
+	  scrot_grab_mouse_pointer(im, rx, ry);
   return im;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -533,8 +533,8 @@ scrot_grab_autoselect(void)
 {
   Imlib_Image im = NULL;
   int rx = opt.autoselect_x, ry = opt.autoselect_y, rw = opt.autoselect_w, rh = opt.autoselect_h;
-  Window target = None;
 
+  scrot_do_delay();
   scrot_nice_clip(&rx, &ry, &rw, &rh);
   im = gib_imlib_create_image_from_drawable(root, 0, rx, ry, rw, rh, 1);
   if (opt.pointer == 1)

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -81,6 +81,7 @@ void scrot_exec_app(Imlib_Image image, struct tm *tm,
 void scrot_do_delay(void);
 Imlib_Image scrot_sel_and_grab_image(void);
 Imlib_Image scrot_grab_focused(void);
+Imlib_Image scrot_grab_autoselect(void);
 void scrot_sel_area(int *x, int *y, int *w, int *h);
 void scrot_nice_clip(int *rx, int *ry, int *rw, int *rh);
 int scrot_get_geometry(Window target, int *rx, int *ry, int *rw, int *rh);


### PR DESCRIPTION
![2020-02-29-210103_1920x1080_scrot](https://user-images.githubusercontent.com/27740271/75616985-84f1f600-5b37-11ea-83da-55e04fdb874a.png)
This fix #39  
I used `scrot_grab_focused()` as an base. 

The screenshot shows the command used (`scrot -a 0,0,1920,1080 -p`) to test, and as shown, the mouse appears.