### PR TITLE
New Feature: capture stack/overlapping windows.

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install_dependencies
-      run: sudo apt install autoconf-archive giblib-dev libimlib2-dev libtool libxcursor-dev libxfixes-dev
+      run: sudo apt install autoconf-archive giblib-dev libimlib2-dev libtool libxcomposite-dev libxcursor-dev libxfixes-dev
     - name: first_build
       run: |
            ./autogen.sh

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -47,6 +47,8 @@ OPTIONS
 
   -o, --overwrite    By default scrot does not overwrite the files, use this option to allow it.
   -n, --note         Draw a text note. See NOTE FORMAT.
+  -k, --stack        Capture stack/overlaped windows and join them together.
+                     A running Composite Manager is needed.
 
 SPECIAL STRINGS
   Both the --exec and filename parameters can take format specifiers that are

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,4 +34,4 @@ LIBOBJS = @LIBOBJS@
 bin_PROGRAMS      = scrot
 scrot_SOURCES       = main.c getopt.c getopt1.c getopt.h scrot.h \
 options.c options.h debug.h imlib.c structs.h note.c note.h
-scrot_LDADD         = -lX11 -lXfixes -lXcursor @GIBLIB_LIBS@
+scrot_LDADD         = -lX11 -lXfixes -lXcursor -lXcomposite @GIBLIB_LIBS@

--- a/src/main.c
+++ b/src/main.c
@@ -830,13 +830,17 @@ scrot_grab_stack_windows(void)
     XImage *ximage          = NULL;
     XWindowAttributes attr;
 
-    Atom atom_prop = XInternAtom(disp, "_NET_CLIENT_LIST", False);
+#define EWMH_CLIENT_LIST "_NET_CLIENT_LIST" // spec EWMH
+
+    Atom atom_prop = XInternAtom(disp, EWMH_CLIENT_LIST, False);
     Atom atom_type = AnyPropertyType;
 
-    if (Success != XGetWindowProperty(disp, root, atom_prop, long_offset, long_length,
+    int result = XGetWindowProperty(disp, root, atom_prop, long_offset, long_length,
                                 delete, atom_type, &actual_type_return, &actual_format_return,
-                                &nitems_return, &bytes_after_return, &prop_return)){
-       fprintf(stderr, "Failed XGetWindowProperty\n");
+                                &nitems_return, &bytes_after_return, &prop_return);
+
+    if (result != Success || nitems_return == 0) {
+       fprintf(stderr, "Failed XGetWindowProperty: " EWMH_CLIENT_LIST "\n");
        exit(EXIT_FAILURE);
     }
 

--- a/src/options.c
+++ b/src/options.c
@@ -53,6 +53,7 @@ init_parse_options(int argc, char **argv)
    opt.line_width = 1;
    opt.line_color = NULL;
    opt.display = NULL;
+   opt.stack = 0;
 
    /* Parse the cmdline args */
    scrot_parse_option_array(argc, argv);
@@ -160,7 +161,7 @@ options_parse_line(char *optarg)
 static void
 scrot_parse_option_array(int argc, char **argv)
 {
-   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zn:l:D:";
+   static char stropts[] = "a:ofpbcd:e:hmq:st:uv+:zn:l:D:k";
 
    static struct option lopts[] = {
       /* actions */
@@ -176,6 +177,7 @@ scrot_parse_option_array(int argc, char **argv)
       {"pointer", 0, 0, 'p'},
       {"freeze", 0, 0, 'f'},
       {"overwrite", 0, 0, 'o'},
+      {"stack", 0, 0,'k'},
       /* toggles */
       {"thumb", 1, 0, 't'},
       {"delay", 1, 0, 'd'},
@@ -258,6 +260,9 @@ scrot_parse_option_array(int argc, char **argv)
         case 'l':
            options_parse_line(optarg);
            break;
+        case 'k':
+           opt.stack = 1;
+        break;
         case '?':
            exit(EXIT_FAILURE);
         default:
@@ -469,7 +474,8 @@ show_usage(void)
            "                            See SELECTION STYLE\n"
            "  -n, --note                Draw a text note.\n"
            "                            See NOTE FORMAT\n"
-
+           "  -k, --stack               Capture stack/overlaped windows and join them together.\n"
+           "                            A running Composite Manager is needed.\n"
            "\n" "  SPECIAL STRINGS\n"
            "  Both the --exec and filename parameters can take format specifiers\n"
            "  that are expanded by " SCROT_PACKAGE " when encountered.\n"

--- a/src/options.h
+++ b/src/options.h
@@ -52,6 +52,7 @@ struct __scrotoptions
    int overwrite;
    int line_style;
    int line_width;
+   int stack;
    char *line_color;
    char *output_file;
    char *thumb_file;

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -39,6 +39,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xresource.h>
 #include <X11/cursorfont.h>
 #include <X11/extensions/Xfixes.h>
+#include <X11/extensions/Xcomposite.h>
 #include <X11/Xcursor/Xcursor.h>
 
 #include <stdio.h>
@@ -94,6 +95,7 @@ char *im_printf(char *str, struct tm *tm,
                 char *filename_im, char *filename_thumb,
                 Imlib_Image im);
 Imlib_Image scrot_grab_shot_multi(void);
+Imlib_Image scrot_grab_stack_windows(void);
 Imlib_Image stalk_image_concat(gib_list *images);
 
 void scrot_grab_mouse_pointer(const Imlib_Image image,


### PR DESCRIPTION

New option: `--stack` or `-k`

Dependencies:

 - Library: libXcomposite (X11)

 - Runtime: Composite Window Manager. Automatic detected.

![scrot_stack](https://user-images.githubusercontent.com/60446893/81028337-6cbc9100-8e70-11ea-9ee3-05eb19066ea2.png)
