### PR TITLE
[#42] autotools: support make dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ man_MANS = man/scrot.1
 #docsdir = $(prefix)/doc/scrot
 
 EXTRA_DIST = \
-scrot.spec scrot.1
+scrot.spec man/scrot.1
 
 SUBDIRS = src
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to create configure.
 
 AC_INIT([scrot], [1.3], [https://github.com/resurrecting-open-source-projects/scrot/issues])
 AC_CONFIG_SRCDIR([src/main.c])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE(dist-bzip2)
 AC_CONFIG_HEADER([src/config.h])
 AX_PREFIX_CONFIG_H([src/scrot_config.h])
 

--- a/scrot.spec
+++ b/scrot.spec
@@ -1,0 +1,21 @@
+Summary:	@PACKAGE@ - command line screen capture utility
+Name:		@PACKAGE@
+Version:	@VERSION@
+Release:	@RELEASE@
+License:	MIT
+URL:		https://github.com/resurrecting-open-source-projects/scrot
+
+%description
+scrot (SCReenshOT) is a simple command line screen capture
+utility that uses imlib2 to grab and save images. Multiple
+image formats are supported through imlib2's dynamic saver
+modules.
+
+Some features of the scrot:
+- support to multiple image formats (JPG, PNG, GIF, etc.).
+- optimization of the screen shots image quality.
+- capture a specific window or a rectangular area on the
+  screen with the help of switch.
+
+scrot also can be used to monitor a desktop PC in admin absent
+and register unwanted activities.


### PR DESCRIPTION
Test. AchLinux - x64
```
$ ./autogen.sh && ./configure && make distcheck
```
Log:
```
===========================================
scrot-1.3 archives ready for distribution: 
scrot-1.3.tar.gz
scrot-1.3.tar.bz2
===========================================
```

```
$ tar xzf scrot-1.3.tar.gz -C /tmp
$ cd /tmp
$ /configure --prefix=/usr
$ make && sudo make install
```
```
$ whereis scrot
scrot: /usr/bin/scrot /usr/share/man/man1/scrot.1
```

Do we need to install the contents of the `doc/`  directory?
