### PR TITLE
Remove libXcursor references, add one libXcomposite reference

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install_dependencies
-      run: sudo apt install autoconf-archive giblib-dev libimlib2-dev libtool libxcomposite-dev libxcursor-dev libxfixes-dev
+      run: sudo apt install autoconf-archive giblib-dev libimlib2-dev libtool libxcomposite-dev libxfixes-dev
     - name: first_build
       run: |
            ./autogen.sh

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ scrot depends of the following libraries/artifacts to build:
   - giblib
   - imlib2
   - libtool
-  - libxcursor
   - libxfixes
 
 To build and install, run the following commands:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ scrot depends of the following libraries/artifacts to build:
   - giblib
   - imlib2
   - libtool
+  - libxcomposite
   - libxfixes
 
 To build and install, run the following commands:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,4 +34,4 @@ LIBOBJS = @LIBOBJS@
 bin_PROGRAMS      = scrot
 scrot_SOURCES       = main.c getopt.c getopt1.c getopt.h scrot.h \
 options.c options.h debug.h imlib.c structs.h note.c note.h
-scrot_LDADD         = -lX11 -lXfixes -lXcursor -lXcomposite @GIBLIB_LIBS@
+scrot_LDADD         = -lX11 -lXfixes -lXcomposite @GIBLIB_LIBS@

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -40,7 +40,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/cursorfont.h>
 #include <X11/extensions/Xfixes.h>
 #include <X11/extensions/Xcomposite.h>
-#include <X11/Xcursor/Xcursor.h>
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
With GNUld --as-needed, the libXcursor linkage is discarded, so nothing that libXcursor provides is actually required in scrot. 