### PR TITLE
Fix SIGSEGV, option --note

### DIFF
--- a/src/note.c
+++ b/src/note.c
@@ -49,12 +49,12 @@ static inline void pfree(char **ptr)
 
 static inline void next_space(char **tok)
 {
-  while (*++*tok == ' ');
+  while (*++*tok == ' ' && **tok != '\0');
 }
 
 static inline void next_not_space(char **tok)
 {
-  while (*++*tok != ' ');
+  while (*++*tok != ' ' && **tok != '\0');
 }
 
 void scrot_note_new(char *format)


### PR DESCRIPTION
The functions next_space() and next_not_space() must detect end of C string
character.