### PR TITLE
Fix SIGSEGV, if running without DISPLAY

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -40,7 +40,8 @@ init_x_and_imlib(char *dispstr, int screen_num)
    disp = XOpenDisplay(dispstr);
    if (!disp) {
       fprintf(stderr, "Can't open X display. It *is* running, yeah? [");
-      fprintf(stderr, "%s", dispstr);
+      fprintf(stderr, "%s", dispstr ? dispstr :
+              (getenv("DISPLAY") ? getenv("DISPLAY") : "NULL"));
       fprintf(stderr, "]");
       exit(EXIT_FAILURE);
    }


### PR DESCRIPTION
Currently if running on a server without DISPLAY set, it will cause segment fault.