### PR TITLE
autotools: optionally debugging symbols

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,19 @@ AC_PATH_GENERIC(giblib, 1.2.3, [
   AC_SUBST(GIBLIB_CFLAGS) ],
   AC_MSG_ERROR(Cannot find giblib: Is giblib-config in the path?) )
 
+AC_ARG_ENABLE(debug,
+    [AS_HELP_STRING([--enable-debug],
+        [enable debugging code (default is no)])],
+    [debug="yes"], [debug="no"])
+
+if test "x$debug" = "xno"
+then
+    CFLAGS="-O3 -DNDEBUG"
+    LDFLAGS="-Wl,-s"
+else
+    CFLAGS="-g -O2 -DDEBUG"
+fi
+
 LIBS="$LIBS -lm"
 GIBLIB_LIBS=`giblib-config --libs`
 GIBLIB_CFLAGS=`giblib-config --cflags`
@@ -33,3 +46,10 @@ m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT
+
+echo "
+    $PACKAGE_NAME version $PACKAGE_VERSION
+    Prefix...........: $prefix
+    Compiler.........: $CC
+    Debug build......: $debug
+"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@
 MAINTAINERCLEANFILES = Makefile.in
 
 AM_LDFLAGS        = -L/usr/X11R6/lib
-AM_CPPFLAGS       = -g -O3 -Wall -I/usr/X11R6/include \
+AM_CPPFLAGS       = -Wall -I/usr/X11R6/include \
 $(X_CFLAGS) -I$(prefix)/include -I$(includedir) -I. \
 -DPREFIX=\""$(prefix)"\" @GIBLIB_CFLAGS@
 LIBOBJS = @LIBOBJS@


### PR DESCRIPTION
Currently scrot compiles with the debugging symbols which is no use to the end user,
it just ends up making the binary bigger.

My PC, x64:
```
With debug symbols    : 126K
Without debug symbols : 47K
```
The debugging symbols and the DEBUG definition is only useful for project collaborators or
anyone who requires it when opening an issue.

Another benefit between Debug and Release is that a contributor can place precondition code(assert) or use:

```C
#ifdef DEBUG
<print a value in the terminal only for the development stage>
#endif
```
Without having to worry that afterwards those code segments are in scrot, which would be useless to the end user.
It is also a communication tool between collaborators, informing others of the objective of a function or code segment.

To generate debug symbols:
```bash
./configure --enable-debug
```