### PR TITLE
Fixed segfault: --multidisp option

### DIFF
--- a/src/imlib.c
+++ b/src/imlib.c
@@ -37,13 +37,6 @@ int depth;
 Window root = 0;
 
 
-/* atexit register func. */
-static void uninit_x_and_imlib(void)
-{
-  if (disp) XCloseDisplay(disp);
-}
-
-
 void
 init_x_and_imlib(char *dispstr, int screen_num)
 {
@@ -55,8 +48,6 @@ init_x_and_imlib(char *dispstr, int screen_num)
       fprintf(stderr, "]\n");
       exit(EXIT_FAILURE);
    }
-
-   atexit(uninit_x_and_imlib);
 
    if (screen_num)
       scr = ScreenOfDisplay(disp, screen_num);

--- a/src/main.c
+++ b/src/main.c
@@ -37,6 +37,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot.h"
 #include "options.h"
 
+
+/* atexit register func. */
+static void uninit_x_and_imlib(void)
+{
+  if (disp) {
+     XCloseDisplay(disp);
+     disp = NULL;
+  }
+}
+
+
 int
 main(int argc,
      char **argv)
@@ -54,6 +65,8 @@ main(int argc,
   init_parse_options(argc, argv);
 
   init_x_and_imlib(opt.display, 0);
+
+  atexit(uninit_x_and_imlib);
 
   if (!opt.output_file) {
     opt.output_file = gib_estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");


### PR DESCRIPTION
This happens because the function `init_x_and_imlib` is reentrant from
`scrot_grab_shot_multi` generating a  double record in `atexit` thus calling `XCloseDisplay` 2 times.