### PR TITLE
Option --class: discriminate windows by class name

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -49,6 +49,7 @@ OPTIONS
   -n, --note         Draw a text note. See NOTE FORMAT.
   -k, --stack        Capture stack/overlapped windows and join them together.
                      A running Composite Manager is needed.
+  -C, --class NAME   Window class name. Associative with options: -k
 
 SPECIAL STRINGS
   Both the --exec and filename parameters can take format specifiers that are

--- a/src/options.h
+++ b/src/options.h
@@ -43,7 +43,7 @@ struct __scrotoptions
    int focused;
    int quality;
    int border;
-   int silent;   
+   int silent;
    int multidisp;
    int thumb;
    int thumb_width;
@@ -60,6 +60,7 @@ struct __scrotoptions
    char *exec;
    char *display;
    char *note;
+   char *window_class_name;
    int autoselect;
    int autoselect_x;
    int autoselect_y;
@@ -74,6 +75,7 @@ void options_parse_autoselect(char *optarg);
 void options_parse_display(char *optarg);
 void options_parse_note(char *optarg);
 int  options_parse_required_number(char *str);
+int  options_cmp_window_class_name(const char* target_class_name);
 extern scrotoptions opt;
 
 #endif

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -5,7 +5,7 @@ Copyright 1999-2000 Tom Gilbert <tom@linuxbrit.co.uk,
                                   scrot_sucks@linuxbrit.co.uk>
 Copyright 2009      James Cameron <quozl@us.netrek.org>
 Copyright 2019      Daniel T. Borelli <danieltborelli@gmail.com>
-Copyright 2020      daltomi <daltomi@disroot.org> 
+Copyright 2020      daltomi <daltomi@disroot.org>
 Copyright 2020      Jeroen Roovers <jer@gentoo.org>
 Copyright 2020      Hinigatsu <hinigatsu@protonmail.com>
 Copyright 2020      spycapitan <spycapitan@protonmail.com>
@@ -89,6 +89,7 @@ Imlib_Image scrot_grab_autoselect(void);
 void scrot_sel_area(int *x, int *y, int *w, int *h);
 void scrot_nice_clip(int *rx, int *ry, int *rw, int *rh);
 int scrot_get_geometry(Window target, int *rx, int *ry, int *rw, int *rh);
+int scrot_match_window_class_name(Window target);
 Window scrot_get_window(Display *display,Window window,int x,int y);
 Window scrot_get_client_window(Display * display, Window target);
 Window scrot_find_window_by_property(Display * display, const Window window,


### PR DESCRIPTION
This is a new feature, it allows discriminating between windows only those that match the class name.

At the moment it is only useful for the `--stack` option, I point it out in the help.
For example, detect only windows with the "XTerm" class:
```
scrot --stack --class "XTerm"
```

I designed the function so that in the future it can be used for other parameters (associative option).

It would be necessary to update the man-page.