### PR TITLE
Support various modes of drawing selection

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -86,13 +86,15 @@ SELECTION STYLE
     style=(solid,dash),width=(range 1 to 8),color="value",
     opacity=(range 10 to 100),mode=(edge,classic)
 
-  The default style are:
+  The default style is:
 
     mode=classic,style=solid,width=1,opacity=100
 
   Mode 'edge' ignore: style, --freeze
 
   Mode 'classic' ignore: opacity
+
+  The 'opacity' specifier is only effective if a Composite Manager is running.
 
   For the color you can use a name or a hexadecimal value.
 

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -83,11 +83,16 @@ SELECTION STYLE
 
   The following specifiers are recognised:
 
-    style=(solid,dash),width=(range 1 to 8),color="value"
+    style=(solid,dash),width=(range 1 to 8),color="value",
+    opacity=(range 10 to 100),mode=(edge,classic)
 
-  The default style is:
+  The default style are:
 
-    style=solid,width=1
+    mode=classic,style=solid,width=1,opacity=100
+
+  Mode 'edge' ignore: style, --freeze
+
+  Mode 'classic' ignore: opacity
 
   For the color you can use a name or a hexadecimal value.
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,6 +34,9 @@ $(X_CFLAGS) -I$(prefix)/include -I$(includedir) -I. \
 LIBOBJS = @LIBOBJS@
 
 bin_PROGRAMS      = scrot
-scrot_SOURCES       = main.c getopt.c getopt1.c getopt.h scrot.h \
-options.c options.h debug.h imlib.c structs.h note.c note.h
-scrot_LDADD         = -lX11 -lXfixes -lXcomposite @GIBLIB_LIBS@
+scrot_SOURCES     = main.c getopt.c getopt1.c getopt.h scrot.h \
+options.c options.h debug.h imlib.c structs.h note.c note.h \
+scrot_selection.c scrot_selection.h \
+selection_classic.c selection_classic.h \
+selection_edge.c selection_edge.h
+scrot_LDADD         = -lX11 -lXfixes -lXext -lXcomposite @GIBLIB_LIBS@

--- a/src/options.c
+++ b/src/options.c
@@ -580,10 +580,11 @@ show_usage(void)
            "  The following specifiers are recognised:\n"
            "                  style=(solid,dash),width=(range 1 to 8),color=\"value\",\n"
            "                  opacity=(range 10 to 100),mode=(edge,classic)\n"
-           "  The default style are:\n"
+           "  The default style is:\n"
            "                  mode=classic,style=solid,width=1,opacity=100\n"
            "  Mode 'edge' ignore    : style, --freeze\n"
-           "  Mode 'classic' ignore : opacity\n"
+           "  Mode 'classic' ignore : opacity\n\n"
+           "  The 'opacity' specifier is only effective if a Composite Manager is running.\n\n"
            "  For the color you can use a name or a hexdecimal value.\n"
            "                  color=\"red\" or color=\"#ff0000\"\n"
            "  Example:\n" "          " SCROT_PACKAGE

--- a/src/options.c
+++ b/src/options.c
@@ -163,7 +163,7 @@ options_parse_line(char *optarg)
 
             bool isValidMode = (bool)(0 == strncmp(value, LINE_MODE_CLASSIC, LINE_MODE_CLASSIC_LEN) );
 
-            isValidMode = (bool)(0 == strncmp(value, LINE_MODE_EDGE, LINE_MODE_EDGE_LEN)) || isValidMode;
+            isValidMode = isValidMode || (bool)(0 == strncmp(value, LINE_MODE_EDGE, LINE_MODE_EDGE_LEN));
 
             if(isValidMode == false) {
                fprintf(stderr, "Unknown value for "

--- a/src/options.c
+++ b/src/options.c
@@ -54,10 +54,8 @@ init_parse_options(int argc, char **argv)
    opt.overwrite = 0;
    opt.line_style = LineSolid;
    opt.line_width = 1;
-   opt.line_color = NULL;
-   opt.display = NULL;
-   opt.stack = 0;
-   opt.window_class_name = NULL;
+   opt.line_opacity = 100;
+   opt.line_mode = LINE_MODE_CLASSIC;
 
    /* Parse the cmdline args */
    scrot_parse_option_array(argc, argv);
@@ -90,12 +88,14 @@ options_parse_required_number(char *str)
 static void
 options_parse_line(char *optarg)
 {
-   enum {STYLE = 0, WIDTH, COLOR };
+   enum {STYLE = 0, WIDTH, COLOR, OPACITY, MODE};
 
    char *const token[] = {
-      [STYLE] = "style",
-      [WIDTH] = "width",
-      [COLOR] = "color",
+      [STYLE]   = "style",
+      [WIDTH]   = "width",
+      [COLOR]   = "color",
+      [OPACITY] = "opacity",
+      [MODE]    = "mode",
       NULL
    };
 
@@ -107,7 +107,7 @@ options_parse_line(char *optarg)
 
          case STYLE:
 
-            if (value == NULL) {
+            if (value == NULL || *value == '\0') {
                fprintf(stderr, "Missing value for "
                      "suboption '%s'\n", token[STYLE]);
                exit(EXIT_FAILURE);
@@ -152,6 +152,47 @@ options_parse_line(char *optarg)
             opt.line_color = strdup(value);
 
             break;
+
+         case MODE:
+
+            if (value == NULL || *value == '\0') {
+               fprintf(stderr, "Missing value for "
+                     "suboption '%s'\n", token[MODE]);
+               exit(EXIT_FAILURE);
+            }
+
+            bool isValidMode = (bool)(0 == strncmp(value, LINE_MODE_CLASSIC, LINE_MODE_CLASSIC_LEN) );
+
+            isValidMode = (bool)(0 == strncmp(value, LINE_MODE_EDGE, LINE_MODE_EDGE_LEN)) || isValidMode;
+
+            if(isValidMode == false) {
+               fprintf(stderr, "Unknown value for "
+                     "suboption '%s': %s\n", token[MODE], value);
+               exit(EXIT_FAILURE);
+            }
+
+            opt.line_mode = strdup(value);
+
+            break;
+
+         case OPACITY:
+
+            if (value == NULL) {
+               fprintf(stderr, "Missing value for "
+                    "suboption '%s'\n", token[OPACITY]);
+               exit(EXIT_FAILURE);
+            }
+
+            opt.line_opacity = options_parse_required_number(value);
+
+            if (opt.line_opacity < 10 || opt.line_opacity > 100){
+               fprintf(stderr, "Value of the range (10..100) for "
+                     "suboption '%s': %d\n", token[OPACITY], opt.line_opacity);
+               exit(EXIT_FAILURE);
+             }
+
+            break;
+
          default:
             fprintf(stderr, "No match found for token: '%s'\n", value);
             exit(EXIT_FAILURE);
@@ -537,9 +578,12 @@ show_usage(void)
            "\n" "  SELECTION STYLE\n"
            "  When using --select you can indicate the style of the line with --line.\n"
            "  The following specifiers are recognised:\n"
-           "                  style=(solid,dash),width=(range 1 to 8),color=\"value\"\n"
+           "                  style=(solid,dash),width=(range 1 to 8),color=\"value\",\n"
+           "                  opacity=(range 10 to 100),mode=(edge,classic)\n"
            "  The default style are:\n"
-           "                  style=solid,width=1\n"
+           "                  mode=classic,style=solid,width=1,opacity=100\n"
+           "  Mode 'edge' ignore    : style, --freeze\n"
+           "  Mode 'classic' ignore : opacity\n"
            "  For the color you can use a name or a hexdecimal value.\n"
            "                  color=\"red\" or color=\"#ff0000\"\n"
            "  Example:\n" "          " SCROT_PACKAGE

--- a/src/options.h
+++ b/src/options.h
@@ -53,8 +53,10 @@ struct __scrotoptions
    int overwrite;
    int line_style;
    int line_width;
+   int line_opacity;
    int stack;
    char *line_color;
+   char *line_mode;
    char *output_file;
    char *thumb_file;
    char *exec;

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -43,6 +43,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/cursorfont.h>
 #include <X11/extensions/Xfixes.h>
 #include <X11/extensions/Xcomposite.h>
+#include <X11/extensions/shape.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -60,6 +61,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <signal.h>
 #include <sys/wait.h>
 #include <giblib/giblib.h>
+#include <stdbool.h>
 
 
 #include "scrot_config.h"
@@ -67,6 +69,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "getopt.h"
 #include "debug.h"
 #include "note.h"
+#include "scrot_selection.h"
 
 #ifndef __GNUC__
 # define __attribute__(x)

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -1,0 +1,148 @@
+/* scrot_selection.c
+
+Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+
+#include "scrot.h"
+#include "selection_classic.h"
+#include "selection_edge.h"
+
+struct selection_t** selection_get(void)
+{
+    static struct selection_t* sel = NULL;
+    return &sel;
+}
+
+static void selection_allocate(void)
+{
+    struct selection_t** sel = selection_get();
+    *sel = calloc(1, sizeof(struct selection_t));
+}
+
+static void selection_deallocate(void)
+{
+    struct selection_t** sel = selection_get();
+    free(*sel);
+    *sel = NULL;
+}
+
+
+void selection_calculate_rect(int x0, int y0, int x1, int y1)
+{
+    struct selection_t* sel = *selection_get();
+    struct selection_rect_t rect = sel->rect;
+
+    rect.x = x0;
+    rect.y = y0;
+    rect.w = x1 - x0;
+    rect.h = y1 - y0;
+
+    if (rect.w == 0) rect.w++;
+
+    if (rect.h == 0) rect.h++;
+
+    if (rect.w < 0) {
+      rect.x += rect.w;
+      rect.w = 0 - rect.w;
+    }
+
+    if (rect.h < 0) {
+      rect.y += rect.h;
+      rect.h = 0 - rect.h;
+    }
+
+    sel->rect = rect;
+}
+
+void scrot_selection_create(void)
+{
+    selection_allocate();
+
+    struct selection_t* sel = *selection_get();
+
+    assert(sel != NULL);
+
+    sel->cur_cross = XCreateFontCursor(disp, XC_cross);
+    sel->cur_angle = XCreateFontCursor(disp, XC_lr_angle);
+
+    if (0 == strncmp(opt.line_mode, LINE_MODE_CLASSIC, LINE_MODE_CLASSIC_LEN)) {
+        sel->create         = selection_classic_create;
+        sel->draw           = selection_classic_draw;
+        sel->motion_draw    = selection_classic_motion_draw;
+        sel->destroy        = selection_classic_destroy;
+    } else if (0 == strncmp(opt.line_mode, LINE_MODE_EDGE, LINE_MODE_EDGE_LEN)) {
+        sel->create         = selection_edge_create;
+        sel->draw           = selection_edge_draw;
+        sel->motion_draw    = selection_edge_motion_draw;
+        sel->destroy        = selection_edge_destroy;
+    } else {
+        // It never happened, fix the options.c file
+        assert(0);
+    }
+
+    sel->create();
+
+    unsigned int const EVENT_MASK = ButtonMotionMask | ButtonPressMask | ButtonReleaseMask;
+
+    if ((XGrabPointer (disp, root, False, EVENT_MASK, GrabModeAsync,
+        GrabModeAsync, root, sel->cur_cross, CurrentTime) != GrabSuccess)) {
+        fprintf(stderr, "couldn't grab pointer\n");
+        scrot_selection_destroy();
+        exit(EXIT_FAILURE);
+    }
+}
+
+
+void scrot_selection_destroy(void)
+{
+    struct selection_t** sel = selection_get();
+    XUngrabPointer(disp, CurrentTime);
+    XFreeCursor(disp, (*sel)->cur_cross);
+    XFreeCursor(disp, (*sel)->cur_angle);
+    XSync(disp, True);
+    (*sel)->destroy();
+    selection_deallocate();
+}
+
+
+void scrot_selection_draw(void)
+{
+    struct selection_t* sel = *selection_get();
+    sel->draw();
+}
+
+
+void scrot_selection_motion_draw(int x0, int y0, int x1, int y1)
+{
+    struct selection_t* sel = *selection_get();
+    unsigned int const EVENT_MASK = ButtonMotionMask | ButtonReleaseMask;
+    XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle, CurrentTime);
+    sel->motion_draw(x0, y0, x1, y1);
+}
+
+struct selection_rect_t scrot_selection_get_rect(void)
+{
+    return (*selection_get())->rect;
+}

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -1,6 +1,6 @@
 /* scrot_selection.c
 
-Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+Copyright 2020  Daniel T. Borelli <daltomi@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -51,7 +51,7 @@ static void selection_deallocate(void)
 
 void selection_calculate_rect(int x0, int y0, int x1, int y1)
 {
-    struct selection_t* sel = *selection_get();
+    struct selection_t *const sel = *selection_get();
     struct selection_rect_t rect = sel->rect;
 
     rect.x = x0;
@@ -80,7 +80,7 @@ void scrot_selection_create(void)
 {
     selection_allocate();
 
-    struct selection_t* sel = *selection_get();
+    struct selection_t *const sel = *selection_get();
 
     assert(sel != NULL);
 
@@ -117,26 +117,26 @@ void scrot_selection_create(void)
 
 void scrot_selection_destroy(void)
 {
-    struct selection_t** sel = selection_get();
+    struct selection_t *const sel = *selection_get();
     XUngrabPointer(disp, CurrentTime);
-    XFreeCursor(disp, (*sel)->cur_cross);
-    XFreeCursor(disp, (*sel)->cur_angle);
+    XFreeCursor(disp, sel->cur_cross);
+    XFreeCursor(disp, sel->cur_angle);
     XSync(disp, True);
-    (*sel)->destroy();
+    sel->destroy();
     selection_deallocate();
 }
 
 
 void scrot_selection_draw(void)
 {
-    struct selection_t* sel = *selection_get();
+    struct selection_t const *const sel = *selection_get();
     sel->draw();
 }
 
 
 void scrot_selection_motion_draw(int x0, int y0, int x1, int y1)
 {
-    struct selection_t* sel = *selection_get();
+    struct selection_t const *const sel = *selection_get();
     unsigned int const EVENT_MASK = ButtonMotionMask | ButtonReleaseMask;
     XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle, CurrentTime);
     sel->motion_draw(x0, y0, x1, y1);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -1,6 +1,6 @@
 /* scrot_selection.h
 
-Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+Copyright 2020  Daniel T. Borelli <daltomi@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -1,0 +1,64 @@
+/* scrot_selection.h
+
+Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+
+#ifndef SCROT_SELECTION_H
+#define SCROT_SELECTION_H
+
+#include <assert.h>
+
+#define LINE_MODE_CLASSIC       "classic"
+#define LINE_MODE_CLASSIC_LEN   7
+#define LINE_MODE_EDGE          "edge"
+#define LINE_MODE_EDGE_LEN      4
+
+struct selection_rect_t {
+    int x, y, w, h;
+};
+
+struct selection_classic_t;
+struct selection_edge_t;
+
+struct selection_t {
+    Cursor cur_cross, cur_angle;
+
+    struct selection_rect_t rect;
+    struct selection_classic_t* classic;
+    struct selection_edge_t* edge;
+
+    void (*create)(void);
+    void (*destroy)(void);
+    void (*draw)(void);
+    void (*motion_draw)(int x0, int y0, int x1, int y1);
+};
+
+void scrot_selection_create(void);
+void scrot_selection_destroy(void);
+void scrot_selection_draw(void);
+void scrot_selection_motion_draw(int x0, int y0, int x1, int y1);
+struct selection_rect_t scrot_selection_get_rect(void);
+
+#endif

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -1,6 +1,6 @@
 /* scrot_selection_classic.c
 
-Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+Copyright 2020  Daniel T. Borelli <daltomi@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -1,0 +1,121 @@
+/* scrot_selection_classic.c
+
+Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+
+#include "selection_classic.h"
+
+extern void selection_calculate_rect(int x0, int y0, int x1, int y1);
+extern struct selection_t** selection_get(void);
+
+struct selection_classic_t {
+    XGCValues gcval;
+    GC gc;
+};
+
+void selection_classic_create(void)
+{
+    struct selection_t* sel = *selection_get();
+
+    sel->classic = calloc(1, sizeof(struct selection_classic_t));
+
+    struct selection_classic_t* pc = sel->classic;
+
+    pc->gcval.function = GXxor;
+    pc->gcval.foreground = XWhitePixel(disp, 0);
+    pc->gcval.background = XBlackPixel(disp, 0);
+    pc->gcval.plane_mask = pc->gcval.background ^ pc->gcval.foreground;
+    pc->gcval.subwindow_mode = IncludeInferiors;
+
+    if (opt.line_color != NULL) {
+        XColor clr_exact, clr_closest;
+        Status ret;
+
+        ret = XAllocNamedColor(disp, XDefaultColormap(disp, DefaultScreen(disp)),
+                opt.line_color, &clr_exact, &clr_closest);
+
+        if (ret == 0) {
+           free(opt.line_color);
+           fprintf(stderr, "Error allocate color:%s\n", strerror(BadColor));
+           scrot_selection_destroy();
+           exit(EXIT_FAILURE);
+        }
+
+        pc->gcval.foreground = clr_exact.pixel;
+
+        free(opt.line_color);
+        opt.line_color = NULL;
+    }
+
+    pc->gc = XCreateGC(disp, root,
+            GCFunction | GCForeground | GCBackground | GCSubwindowMode,
+            &pc->gcval);
+
+    assert(pc->gc != NULL);
+
+    XSetLineAttributes(disp, pc->gc, opt.line_width, opt.line_style, CapRound, JoinRound);
+
+    if (opt.freeze == 1) {
+        XGrabServer(disp);
+    }
+}
+
+
+void selection_classic_destroy()
+{
+    struct selection_t const *const sel = *selection_get();
+    struct selection_classic_t* pc = sel->classic;
+  
+    if (opt.freeze == 1) {
+        XUngrabServer(disp);
+    }
+
+    if (pc->gc) {
+        XFreeGC(disp, pc->gc);
+    }
+
+    free(pc);
+}
+
+
+void selection_classic_draw()
+{
+    struct selection_t const *const sel = *selection_get();
+    struct selection_classic_t const *const pc = sel->classic;
+    XDrawRectangle(disp, root, pc->gc, sel->rect.x, sel->rect.y, sel->rect.w, sel->rect.h);
+    XFlush(disp);
+}
+
+
+void selection_classic_motion_draw(int x0, int y0, int x1, int y1)
+{
+    struct selection_t const *const sel = *selection_get();
+
+    if (sel->rect.w) {
+        selection_classic_draw();
+    }
+    selection_calculate_rect(x0, y0, x1, y1);
+    selection_classic_draw();
+}

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -37,7 +37,7 @@ struct selection_classic_t {
 
 void selection_classic_create(void)
 {
-    struct selection_t* sel = *selection_get();
+    struct selection_t *const sel = *selection_get();
 
     sel->classic = calloc(1, sizeof(struct selection_classic_t));
 

--- a/src/selection_classic.h
+++ b/src/selection_classic.h
@@ -1,0 +1,36 @@
+/* scrot_selection_classic.h
+
+Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+#ifndef SELECTION_CLASSIC_H
+#define SELECTION_CLASSIC_H
+
+#include "scrot.h"
+
+void selection_classic_create(void);
+void selection_classic_destroy();
+void selection_classic_draw(void);
+void selection_classic_motion_draw(int x0, int y0, int x1, int y1);
+#endif

--- a/src/selection_classic.h
+++ b/src/selection_classic.h
@@ -1,6 +1,6 @@
 /* scrot_selection_classic.h
 
-Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+Copyright 2020  Daniel T. Borelli <daltomi@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -37,11 +37,11 @@ struct selection_edge_t {
 
 void selection_edge_create(void)
 { 
-    struct selection_t* sel = *selection_get();
+    struct selection_t *const sel = *selection_get();
 
     sel->edge = calloc(1, sizeof(struct selection_edge_t));
 
-    struct selection_edge_t* pe = sel->edge;
+    struct selection_edge_t *const pe = sel->edge;
 
     // It is ok that in the "classic" mode it is to NULL, but it is not "edge" mode
     if (opt.line_color == NULL) {
@@ -80,8 +80,8 @@ void selection_edge_create(void)
 
 void selection_edge_destroy()
 {
-    struct selection_t* sel = *selection_get();
-    struct selection_edge_t* pe = sel->edge;
+    struct selection_t const *const sel = *selection_get();
+    struct selection_edge_t *pe = sel->edge;
 
     XUnmapWindow(disp, pe->wndDraw);
     XDestroyWindow(disp, pe->wndDraw);
@@ -91,8 +91,8 @@ void selection_edge_destroy()
 
 void selection_edge_draw(void)
 {
-    struct selection_t const* const sel = *selection_get();
-    struct selection_edge_t const* const  pe = sel->edge;
+    struct selection_t const *const sel = *selection_get();
+    struct selection_edge_t const *const  pe = sel->edge;
 
     XRectangle rects[4] = {
             {sel->rect.x, sel->rect.y, opt.line_width, sel->rect.h},                                    //left

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -34,6 +34,7 @@ struct selection_edge_t {
     Window wndDraw;
 };
 
+
 void selection_edge_create(void)
 { 
     struct selection_t* sel = *selection_get();
@@ -76,6 +77,7 @@ void selection_edge_create(void)
                   1L);
 }
 
+
 void selection_edge_destroy()
 {
     struct selection_t* sel = *selection_get();
@@ -86,21 +88,11 @@ void selection_edge_destroy()
     free(pe);
 }
 
+
 void selection_edge_draw(void)
-{ /*UNUSED*/ }
-
-
-void selection_edge_motion_draw(int x0, int y0, int x1, int y1)
 {
-    selection_calculate_rect(x0, y0, x1, y1);
-
-    struct selection_t* sel = *selection_get();
-    struct selection_edge_t* pe = sel->edge;
-
-    sel->rect.x -= opt.line_width;
-    sel->rect.y -= opt.line_width;
-    sel->rect.w += opt.line_width;
-    sel->rect.h += opt.line_width;
+    struct selection_t const* const sel = *selection_get();
+    struct selection_edge_t const* const  pe = sel->edge;
 
     XRectangle rects[4] = {
             {sel->rect.x, sel->rect.y, opt.line_width, sel->rect.h},                                    //left
@@ -111,4 +103,19 @@ void selection_edge_motion_draw(int x0, int y0, int x1, int y1)
 
     XShapeCombineRectangles(disp, pe->wndDraw, ShapeBounding, 0, 0, rects, 4, ShapeSet, 0);
     XMapWindow(disp, pe->wndDraw);
+}
+
+
+void selection_edge_motion_draw(int x0, int y0, int x1, int y1)
+{
+    struct selection_t *const sel = *selection_get();
+
+    selection_calculate_rect(x0, y0, x1, y1);
+
+    sel->rect.x -= opt.line_width;
+    sel->rect.y -= opt.line_width;
+    sel->rect.w += opt.line_width;
+    sel->rect.h += opt.line_width;
+
+    selection_edge_draw();
 }

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -1,6 +1,6 @@
 /* scrot_selection_edge.c
 
-Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+Copyright 2020  Daniel T. Borelli <daltomi@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -1,0 +1,114 @@
+/* scrot_selection_edge.c
+
+Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+
+#include "scrot.h"
+
+extern void selection_calculate_rect(int x0, int y0, int x1, int y1);
+extern struct selection_t** selection_get(void);
+
+struct selection_edge_t {
+    Window wndDraw;
+};
+
+void selection_edge_create(void)
+{ 
+    struct selection_t* sel = *selection_get();
+
+    sel->edge = calloc(1, sizeof(struct selection_edge_t));
+
+    struct selection_edge_t* pe = sel->edge;
+
+    // It is ok that in the "classic" mode it is to NULL, but it is not "edge" mode
+    if (opt.line_color == NULL) {
+        opt.line_color = "gray";
+    }
+
+    XColor color;
+
+    if (0 == XAllocNamedColor(disp, XDefaultColormap(disp, DefaultScreen(disp)), 
+                opt.line_color, &color, &(XColor){})) 
+    {
+        fprintf(stderr, "Error allocate color:%s\n", strerror(BadColor));
+        scrot_selection_destroy();
+        exit(EXIT_FAILURE);
+    }
+
+    XSetWindowAttributes attr;
+    attr.background_pixel = color.pixel;
+    attr.override_redirect = True;
+
+    pe->wndDraw = XCreateWindow(disp, root, 0, 0, WidthOfScreen(scr), HeightOfScreen(scr), 0,
+          CopyFromParent, InputOutput, CopyFromParent, CWOverrideRedirect | CWBackPixel, &attr);
+
+    unsigned long opacity = opt.line_opacity * ((unsigned)-1 / 100);
+
+    XChangeProperty(disp, pe->wndDraw, XInternAtom(disp, "_NET_WM_WINDOW_OPACITY", False),
+                  XA_CARDINAL, 32, PropModeReplace,
+                  (unsigned char*)&opacity, 1L);
+
+    XChangeProperty(disp, pe->wndDraw, XInternAtom(disp, "_NET_WM_WINDOW_TYPE", False),
+                  XA_ATOM, 32, PropModeReplace,
+                  (unsigned char*)&(Atom){XInternAtom(disp, "_NET_WM_WINDOW_TYPE_DOCK", False)},
+                  1L);
+}
+
+void selection_edge_destroy()
+{
+    struct selection_t* sel = *selection_get();
+    struct selection_edge_t* pe = sel->edge;
+
+    XUnmapWindow(disp, pe->wndDraw);
+    XDestroyWindow(disp, pe->wndDraw);
+    free(pe);
+}
+
+void selection_edge_draw(void)
+{ /*UNUSED*/ }
+
+
+void selection_edge_motion_draw(int x0, int y0, int x1, int y1)
+{
+    selection_calculate_rect(x0, y0, x1, y1);
+
+    struct selection_t* sel = *selection_get();
+    struct selection_edge_t* pe = sel->edge;
+
+    sel->rect.x -= opt.line_width;
+    sel->rect.y -= opt.line_width;
+    sel->rect.w += opt.line_width;
+    sel->rect.h += opt.line_width;
+
+    XRectangle rects[4] = {
+            {sel->rect.x, sel->rect.y, opt.line_width, sel->rect.h},                                    //left
+            {sel->rect.x, sel->rect.y, sel->rect.w, opt.line_width},                                    //top
+            {sel->rect.x + sel->rect.w, sel->rect.y, opt.line_width, sel->rect.h},                      //right
+            {sel->rect.x, sel->rect.y + sel->rect.h, sel->rect.w + opt.line_width, opt.line_width}      //bottom
+    };
+
+    XShapeCombineRectangles(disp, pe->wndDraw, ShapeBounding, 0, 0, rects, 4, ShapeSet, 0);
+    XMapWindow(disp, pe->wndDraw);
+}

--- a/src/selection_edge.h
+++ b/src/selection_edge.h
@@ -1,0 +1,38 @@
+/* scrot_selection_edge.h
+
+Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* This file is part of the scrot project. */
+
+#ifndef SELECTION_EDGE_H
+#define SELECTION_EDGE_H
+
+#include "scrot.h"
+
+void selection_edge_create(void);
+void selection_edge_destroy();
+void selection_edge_draw(void);
+void selection_edge_motion_draw(int x0, int y0, int x1, int y1);
+
+#endif

--- a/src/selection_edge.h
+++ b/src/selection_edge.h
@@ -1,6 +1,6 @@
 /* scrot_selection_edge.h
 
-Copyright 2020  Daniel T. Borelli <daltomi@disroot>
+Copyright 2020  Daniel T. Borelli <daltomi@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
WIP #60, #37 

Big refactoring of the `scrot_sel_and_grab_image()` function

- New `mode` specifier for `--line` option, supports `classic` (default) and `edge`

- New files: `scrot_selection.{c,h}`, `selection_edge.{c,h}`, `selection_classic.{c,h}`

- Use stdbool.h (C99)

More info: https://github.com/resurrecting-open-source-projects/scrot/issues/60#issuecomment-723329026

Note:  I prefixed the branch `wip-` because it is only to work, not to merge with `master`, for that I'm going to create another branch and use `--squash` to create a single commit message.
