### PR TITLE
Fix compilation on Sparc64 (on OpenBSD)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -311,8 +311,9 @@ scrot_grab_mouse_pointer(const Imlib_Image image,
   pixels = (DATA32*)xcim->pixels;
 #else
   DATA32 data[width * height * 4];
-
-  for (size_t i = 0; i < (width * height); i++)
+  
+  size_t i;
+  for (i = 0; i < (width * height); i++)
     ((DATA32*)data)[i] = (DATA32)xcim->pixels[i];
 
   pixels = data;
@@ -829,7 +830,8 @@ scrot_grab_stack_windows(void)
 
     XCompositeRedirectSubwindows(disp, root, CompositeRedirectAutomatic);
 
-    for (int i = 0; i < nitems_return; i++) {
+    int i;
+    for (i = 0; i < nitems_return; i++) {
 
         Window win = *((Window*)prop_return + i);
 


### PR DESCRIPTION
Hello,

I tried to compile scrot on OpenBSD/Sparc64 and it ran into compile errors due to two inline declarations that aren't strictly c99.

```
main.c: In function 'scrot_grab_mouse_pointer':
main.c:257: error: 'for' loop initial declaration used outside C99 mode
main.c: In function 'scrot_grab_stack_windows':
main.c:850: error: 'for' loop initial declaration used outside C99 mode
```

This pull request moves the declaration out of the for loops.

This fixes the compilation on sparc64 without relaxing the C standard.