### PR TITLE
Fix various typos

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -666,7 +666,7 @@ im_printf(char *str, struct tm *tm,
           if (filename_im)
             strcat(ret, filename_im);
           break;
-        case 'm': /* t was allready taken, so m as in mini */
+        case 'm': /* t was already taken, so m as in mini */
           if (filename_thumb)
             strcat(ret, filename_thumb);
           break;

--- a/src/options.c
+++ b/src/options.c
@@ -549,7 +549,7 @@ show_usage(void)
            "                            See SELECTION STYLE\n"
            "  -n, --note                Draw a text note.\n"
            "                            See NOTE FORMAT\n"
-           "  -k, --stack               Capture stack/overlaped windows and join them together.\n"
+           "  -k, --stack               Capture stack/overlapped windows and join them together.\n"
            "                            A running Composite Manager is needed.\n"
            "  -C,  --class NAME         Window class name. Associative with options: -k\n"
            "\n" "  SPECIAL STRINGS\n"
@@ -586,7 +586,7 @@ show_usage(void)
            "  Mode 'edge' ignore    : style, --freeze\n"
            "  Mode 'classic' ignore : opacity\n\n"
            "  The 'opacity' specifier is only effective if a Composite Manager is running.\n\n"
-           "  For the color you can use a name or a hexdecimal value.\n"
+           "  For the color you can use a name or a hexadecimal value.\n"
            "                  color=\"red\" or color=\"#ff0000\"\n"
            "  Example:\n" "          " SCROT_PACKAGE
            " --line style=dash,width=3,color=\"red\" --select\n\n"


### PR DESCRIPTION
Found via `codespell -q 3`