### PR TITLE
Wait for the window to finish rising

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -25,6 +25,7 @@ OPTIONS
   -D, --display      Specify the display to use; see X(7).
   -a, --autoselect   Non-interactively choose a rectangle of x,y,w,h.
   -b, --border       When selecting a window, grab wm border too.
+                     Use with --select to raise the focus of the window.
   -c, --count        Display a countdown when used with delay.
   -d, --delay NUM    Wait NUM seconds before taking a shot.
   -e, --exec APP     Exec APP on the saved image.

--- a/src/main.c
+++ b/src/main.c
@@ -578,17 +578,20 @@ scrot_get_geometry(Window target,
       Window rt, *children, parent;
 
       for (;;) {
-	/* Find window manager frame. */
-	status = XQueryTree(disp, target, &rt, &parent, &children, &d);
-	if (status && (children != None))
-	  XFree((char *) children);
-	if (!status || (parent == None) || (parent == rt))
-	  break;
-	target = parent;
+        /* Find window manager frame. */
+        status = XQueryTree(disp, target, &rt, &parent, &children, &d);
+        if (status && (children != None)) {
+          XFree((char *) children);
+        }
+        if (!status || (parent == None) || (parent == rt)) {
+            break;
+        }
+        target = parent;
       }
       /* Get client window. */
-      if (!opt.border)
-	target = scrot_get_client_window(disp, target);
+      if (!opt.border) {
+        target = scrot_get_client_window(disp, target);
+      }
       XRaiseWindow(disp, target);
     }
   }

--- a/src/options.c
+++ b/src/options.c
@@ -526,6 +526,7 @@ show_usage(void)
            "  -D, --display             Set DISPLAY target other than current\n"
            "  -a, --autoselect          non-interactively choose a rectangle of x,y,w,h\n"
            "  -b, --border              When selecting a window, grab wm border too\n"
+           "                            Use with --select to raise the focus of the window.\n"
            "  -c, --count               show a countdown before taking the shot\n"
            "  -d, --delay NUM           wait NUM seconds before taking a shot\n"
            "  -e, --exec APP            run APP on the resulting screenshot\n"


### PR DESCRIPTION
Give the WM time to update the hidden area of the window.
 When using the `scrot --select --border` option and clicking on a window that is hidden behind another,  this happens:

![bad_focus_window2](https://user-images.githubusercontent.com/73098402/110728792-8b6c8080-8215-11eb-8463-e953b6972e9f.png)


This commit fixes that, waiting for the `FocusChangedMask` event or if it timed out.