### PR TITLE
Increase scrot_nice_clip() 'x' and 'y' by 1 when using --select

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -597,6 +597,11 @@ scrot_nice_clip(int *rx,
     *rw = scr->width - *rx;
   if ((*ry + *rh) > scr->height)
     *rh = scr->height - *ry;
+
+  if (opt.select) {
+    ++*rx;
+    ++*ry;
+  }
 }
 
 static Bool scrot_xevent_visibility(Display *dpy, XEvent *ev, XPointer arg)


### PR DESCRIPTION
fix #77