### PR TITLE
Increase 'rx' and 'ry' size by 1 to avoid bad clipping when using --select

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -555,6 +555,9 @@ key_abort_shot:
     }
     scrot_nice_clip(&rx, &ry, &rw, &rh);
 
+    ++rx;
+    ++ry;
+
     if (! opt.silent) XBell(disp, 0);
     im = gib_imlib_create_image_from_drawable(root, 0, rx, ry, rw, rh, 1);
 


### PR DESCRIPTION
fix #77

I set the i3wm border to 1px and now scrot is able to grab it (the thin blue line at bottom and right edges)

![image](https://user-images.githubusercontent.com/27740271/112731009-81d06180-8f13-11eb-8ccb-990d050fe570.png)
