### PR TITLE
Added 3 other corner cursors when selecting an area

### DIFF
--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -86,7 +86,10 @@ void scrot_selection_create(void)
     assert(sel != NULL);
 
     sel->cur_cross = XCreateFontCursor(disp, XC_cross);
-    sel->cur_angle = XCreateFontCursor(disp, XC_lr_angle);
+    sel->cur_angle_ne = XCreateFontCursor(disp, XC_ur_angle);
+    sel->cur_angle_nw = XCreateFontCursor(disp, XC_ul_angle);
+    sel->cur_angle_se = XCreateFontCursor(disp, XC_lr_angle);
+    sel->cur_angle_sw = XCreateFontCursor(disp, XC_ll_angle);
 
     if (0 == strncmp(opt.line_mode, LINE_MODE_CLASSIC, LINE_MODE_CLASSIC_LEN)) {
         sel->create         = selection_classic_create;
@@ -121,7 +124,7 @@ void scrot_selection_destroy(void)
     struct selection_t *const sel = *selection_get();
     XUngrabPointer(disp, CurrentTime);
     XFreeCursor(disp, sel->cur_cross);
-    XFreeCursor(disp, sel->cur_angle);
+    XFreeCursor(disp, sel->cur_angle_se);
     XSync(disp, True);
     sel->destroy();
     selection_deallocate();
@@ -139,7 +142,15 @@ void scrot_selection_motion_draw(int x0, int y0, int x1, int y1)
 {
     struct selection_t const *const sel = *selection_get();
     unsigned int const EVENT_MASK = ButtonMotionMask | ButtonReleaseMask;
-    XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle, CurrentTime);
+	if (x1 > x0 && y1 > y0) {
+		XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle_se, CurrentTime);
+	} else if (x1 > x0) {
+		XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle_ne, CurrentTime);
+	} else if (y1 > y0) {
+		XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle_sw, CurrentTime);
+	} else {
+		XChangeActivePointerGrab(disp, EVENT_MASK, sel->cur_angle_nw, CurrentTime);
+	}
     sel->motion_draw(x0, y0, x1, y1);
 }
 

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -47,7 +47,7 @@ struct selection_classic_t;
 struct selection_edge_t;
 
 struct selection_t {
-    Cursor cur_cross, cur_angle;
+    Cursor cur_cross, cur_angle_nw, cur_angle_ne, cur_angle_sw, cur_angle_se;
 
     struct selection_rect_t rect;
     struct selection_classic_t* classic;


### PR DESCRIPTION
When **selecting** an area to screenshot from the **bottom left** corner to the **top right** corner, I noticed the cursor icon was a **south-east** angle one, which was kind of funny-looking, so I downloaded the source code and add more variables for cursor icons and conditions to display which.

I've also recompiled and installed the modified package on my end, and it worked out great!