### PR TITLE
Decouple giblib from scrot: resurrect/retire giblib as well? #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Nowadays, scrot is maintained by volunteers.
 scrot depends of the following libraries/artifacts to build:
 
   - autoconf-archive
-  - giblib
   - imlib2
   - libtool
   - libxcomposite

--- a/configure.ac
+++ b/configure.ac
@@ -15,12 +15,17 @@ AC_PROG_MAKE_SET
 
 AM_MAINTAINER_MODE
 
-AC_PATH_GENERIC(giblib, 1.2.3, [
-  AC_SUBST(GIBLIB_LIBS)
-  AC_SUBST(GIBLIB_CFLAGS) ],
-  AC_MSG_ERROR(Cannot find giblib: Is giblib-config in the path?) )
+AC_PATH_GENERIC(Imlib2, , [
+  AC_SUBST(IMLIB2_LIBS)
+  AC_SUBST(IMLIB2_CFLAGS) ],
+  AC_MSG_ERROR(Cannot find Imlib2: Is imlib2-config in the path?) )
 
-LIBS="$LIBS -lm -lImlib2"
+
+LIBS="$LIBS -lm"
+IMLIB2_LIBS=`imlib2-config --libs`
+IMLIB2_CFLAGS=`imlib2-config --cflags`
+AC_SUBST(IMLIB2_LIBS)
+AC_SUBST(IMLIB2_CFLAGS)
 
 AC_CHECK_FUNC(getopt_long,,[LIBOBJS="$LIBOBJS getopt.o getopt1.o"])
 AC_SUBST(LIBOBJS)

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_SUBST(IMLIB2_CFLAGS)
 
 AC_CHECK_FUNC(getopt_long,,[LIBOBJS="$LIBOBJS getopt.o getopt1.o"])
 AC_SUBST(LIBOBJS)
-AC_CHECK_FUNC(strdup,,)
+AC_CHECK_FUNCS(strdup)
 
 m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,11 +20,7 @@ AC_PATH_GENERIC(giblib, 1.2.3, [
   AC_SUBST(GIBLIB_CFLAGS) ],
   AC_MSG_ERROR(Cannot find giblib: Is giblib-config in the path?) )
 
-LIBS="$LIBS -lm"
-GIBLIB_LIBS=`giblib-config --libs`
-GIBLIB_CFLAGS=`giblib-config --cflags`
-AC_SUBST(GIBLIB_LIBS)
-AC_SUBST(GIBLIB_CFLAGS)
+LIBS="$LIBS -lm -lImlib2"
 
 AC_CHECK_FUNC(getopt_long,,[LIBOBJS="$LIBOBJS getopt.o getopt1.o"])
 AC_SUBST(LIBOBJS)

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,7 @@ AC_SUBST(GIBLIB_CFLAGS)
 
 AC_CHECK_FUNC(getopt_long,,[LIBOBJS="$LIBOBJS getopt.o getopt1.o"])
 AC_SUBST(LIBOBJS)
+AC_CHECK_FUNC(strdup,,)
 
 m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,7 +30,7 @@ MAINTAINERCLEANFILES = Makefile.in
 AM_LDFLAGS        = -L/usr/X11R6/lib
 AM_CPPFLAGS       = -g -O3 -Wall -I/usr/X11R6/include \
 $(X_CFLAGS) -I$(prefix)/include -I$(includedir) -I. \
--DPREFIX=\""$(prefix)"\" @GIBLIB_CFLAGS@
+-DPREFIX=\""$(prefix)"\" @IMLIB2_CFLAGS@
 LIBOBJS = @LIBOBJS@
 
 bin_PROGRAMS      = scrot
@@ -41,4 +41,4 @@ selection_classic.c selection_classic.h \
 selection_edge.c selection_edge.h \
 utils.c utils.h \
 slist.c slict.h
-scrot_LDADD         = -lX11 -lXfixes -lXext -lXcomposite @GIBLIB_LIBS@
+scrot_LDADD         = -lX11 -lXfixes -lXext -lXcomposite @IMLIB2_LIBS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,5 +38,7 @@ scrot_SOURCES     = main.c getopt.c getopt1.c getopt.h scrot.h \
 options.c options.h debug.h imlib.c structs.h note.c note.h \
 scrot_selection.c scrot_selection.h \
 selection_classic.c selection_classic.h \
-selection_edge.c selection_edge.h
+selection_edge.c selection_edge.h \
+utils.c utils.h \
+slist.c slict.h
 scrot_LDADD         = -lX11 -lXfixes -lXext -lXcomposite @GIBLIB_LIBS@

--- a/src/main.c
+++ b/src/main.c
@@ -177,6 +177,7 @@ main(int argc,
                                             twidth, theight);
     if (thumbnail == NULL) {
       fprintf(stderr, "Unable to create scaled Image: %s\n", strerror(errno));
+      exit(EXIT_FAILURE);
     }
     else
     {
@@ -198,6 +199,7 @@ main(int argc,
       imlib_save_image_with_error_return(filename_thumb, &err);
       if (err) {
         fprintf(stderr, "Saving thumbnail %s failed: %s\n", filename_thumb, strerror(errno));
+	exit(EXIT_FAILURE);
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@ Copyright 2020      nothub
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2020      spycapitan <spycapitan@protonmail.com>
 Copyright 2021      c0dev0id <sh+github@codevoid.de>
+Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -40,6 +41,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "scrot.h"
 #include "options.h"
+#include "utils.h"
+#include "slist.h"
 #include <assert.h>
 
 
@@ -82,8 +85,8 @@ main(int argc,
   atexit(uninit_x_and_imlib);
 
   if (!opt.output_file) {
-    opt.output_file = gib_estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
-    opt.thumb_file = gib_estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
+    opt.output_file = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
+    opt.thumb_file = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
   } else {
     scrot_have_file_extension(opt.output_file, &have_extension);
   }
@@ -110,8 +113,10 @@ main(int argc,
   if (opt.note != NULL)
     scrot_note_draw(image);
 
-  if (!image)
-    gib_eprintf("no image grabbed");
+  if (!image) {
+    fprintf(stderr, "no image grabbed: %s", strerror(errno));
+    exit(EXIT_FAILURE);
+  }
 
   time(&t); /* Get the time directly after the screenshot */
   tm = localtime(&t);
@@ -128,16 +133,18 @@ main(int argc,
 
   apply_filter_if_required();
 
-  gib_imlib_save_image_with_error_return(image, filename_im, &err);
-  if (err)
-    gib_eprintf("Saving to file %s failed\n", filename_im);
+  imlib_save_image_with_error_return(filename_im, &err);
+  if (err) {
+    fprintf(stderr, "Saving to file %s failed: %s\n", filename_im, strerror(errno));
+    exit(EXIT_FAILURE);
+  }
   if (opt.thumb)
   {
     int cwidth, cheight;
     int twidth, theight;
 
-    cwidth = gib_imlib_image_get_width(image);
-    cheight = gib_imlib_image_get_height(image);
+    cwidth = imlib_image_get_width();
+    cheight = imlib_image_get_height();
 
     /* Geometry based thumb size */
     if (opt.thumb_width || opt.thumb_height)
@@ -164,11 +171,13 @@ main(int argc,
       theight = cheight * opt.thumb / 100;
     }
 
+    imlib_context_set_anti_alias(1);
     thumbnail =
-      gib_imlib_create_cropped_scaled_image(image, 0, 0, cwidth, cheight,
-                                            twidth, theight, 1);
-    if (thumbnail == NULL)
-      gib_eprintf("Unable to create scaled Image\n");
+      imlib_create_cropped_scaled_image(0, 0, cwidth, cheight,
+                                            twidth, theight);
+    if (thumbnail == NULL) {
+      fprintf(stderr, "Unable to create scaled Image: %s\n", strerror(errno));
+    }
     else
     {
       if (opt.note != NULL)
@@ -186,14 +195,15 @@ main(int argc,
 
       apply_filter_if_required();
 
-      gib_imlib_save_image_with_error_return(thumbnail, filename_thumb, &err);
-      if (err)
-        gib_eprintf("Saving thumbnail %s failed\n", filename_thumb);
+      imlib_save_image_with_error_return(filename_thumb, &err);
+      if (err) {
+        fprintf(stderr, "Saving thumbnail %s failed: %s\n", filename_thumb, strerror(errno));
+      }
     }
   }
   if (opt.exec)
     scrot_exec_app(image, tm, filename_im, filename_thumb);
-  gib_imlib_free_image_and_decache(image);
+  imlib_free_image_and_decache();
 
   return 0;
 }
@@ -362,7 +372,7 @@ scrot_grab_shot(void)
   if (! opt.silent) XBell(disp, 0);
 
   im =
-    gib_imlib_create_image_from_drawable(root, 0, 0, 0, scr->width,
+    imlib_create_image_from_drawable(0, 0, 0, scr->width,
                                          scr->height, 1);
   if (opt.pointer == 1)
     scrot_grab_mouse_pointer(im, 0, 0);
@@ -404,7 +414,7 @@ scrot_grab_focused(void)
   XGetInputFocus(disp, &target, &ignored);
   if (!scrot_get_geometry(target, &rx, &ry, &rw, &rh)) return NULL;
   scrot_nice_clip(&rx, &ry, &rw, &rh);
-  im = gib_imlib_create_image_from_drawable(root, 0, rx, ry, rw, rh, 1);
+  im = imlib_create_image_from_drawable(0, rx, ry, rw, rh, 1);
   if (opt.pointer == 1)
 	  scrot_grab_mouse_pointer(im, rx, ry);
   return im;
@@ -564,7 +574,7 @@ key_abort_shot:
     scrot_nice_clip(&rx, &ry, &rw, &rh);
 
     if (! opt.silent) XBell(disp, 0);
-    im = gib_imlib_create_image_from_drawable(root, 0, rx, ry, rw, rh, 1);
+    im = imlib_create_image_from_drawable(0, rx, ry, rw, rh, 1);
 
     if (opt.pointer == 1)
        scrot_grab_mouse_pointer(im, rx, ry);
@@ -580,7 +590,7 @@ scrot_grab_autoselect(void)
 
   scrot_do_delay();
   scrot_nice_clip(&rx, &ry, &rw, &rh);
-  im = gib_imlib_create_image_from_drawable(root, 0, rx, ry, rw, rh, 1);
+  im = imlib_create_image_from_drawable(0, rx, ry, rw, rh, 1);
   if (opt.pointer == 1)
 	  scrot_grab_mouse_pointer(im, rx, ry);
   return im;
@@ -736,6 +746,7 @@ im_printf(char *str, struct tm *tm,
     exit(EXIT_FAILURE);
   }
 
+  imlib_context_set_image(im);
   for (c = strf; *c != '\0'; c++) {
     if (*c == '$') {
       c++;
@@ -762,11 +773,11 @@ im_printf(char *str, struct tm *tm,
           }
           break;
         case 'w':
-          snprintf(buf, sizeof(buf), "%d", gib_imlib_image_get_width(im));
+          snprintf(buf, sizeof(buf), "%d", imlib_image_get_width());
           strcat(ret, buf);
           break;
         case 'h':
-          snprintf(buf, sizeof(buf), "%d", gib_imlib_image_get_height(im));
+          snprintf(buf, sizeof(buf), "%d", imlib_image_get_height());
           strcat(ret, buf);
           break;
         case 's':
@@ -783,14 +794,14 @@ im_printf(char *str, struct tm *tm,
           break;
         case 'p':
           snprintf(buf, sizeof(buf), "%d",
-                   gib_imlib_image_get_width(im) *
-                   gib_imlib_image_get_height(im));
+                   imlib_image_get_width() *
+                   imlib_image_get_height());
           strcat(ret, buf);
           break;
         case 't':
-          tmp = gib_imlib_image_format(im);
+          tmp = imlib_image_format();
           if (tmp) {
-            strcat(ret, gib_imlib_image_format(im));
+            strcat(ret, tmp);
           }
           break;
         case '$':
@@ -817,7 +828,7 @@ im_printf(char *str, struct tm *tm,
       ret[len + 1] = '\0';
     }
   }
-  return gib_estrdup(ret);
+  return strdup(ret);
 }
 
 Window
@@ -895,7 +906,7 @@ scrot_grab_stack_windows(void)
     Bool delete      = False;
     int actual_format_return;
     Atom actual_type_return;
-    gib_list *list_images   = NULL;
+    Scrot_Imlib_List *list_images   = NULL;
     Imlib_Image im          = NULL;
     XImage *ximage          = NULL;
     XWindowAttributes attr;
@@ -946,7 +957,7 @@ scrot_grab_stack_windows(void)
 
         XFree(ximage);
 
-        list_images = gib_list_add_end(list_images, im);
+        list_images = append_to_scrot_imlib(list_images, im);
     }
 
     return stalk_image_concat(list_images);
@@ -959,14 +970,14 @@ scrot_grab_shot_multi(void)
   int i;
   char *dispstr, *subdisp;
   char newdisp[255];
-  gib_list *images = NULL;
+  Scrot_Imlib_List *images = NULL;
   Imlib_Image ret = NULL;
 
   screens = ScreenCount(disp);
   if (screens < 2)
     return scrot_grab_shot();
 
-  subdisp = gib_estrdup(DisplayString(disp));
+  subdisp = strdup(DisplayString(disp));
 
   for (i = 0; i < screens; i++) {
     dispstr = strchr(subdisp, ':');
@@ -978,9 +989,9 @@ scrot_grab_shot_multi(void)
     snprintf(newdisp, sizeof(newdisp), "%s.%d", subdisp, i);
     init_x_and_imlib(newdisp, i);
     ret =
-      gib_imlib_create_image_from_drawable(root, 0, 0, 0, scr->width,
+      imlib_create_image_from_drawable(0, 0, 0, scr->width,
                                            scr->height, 1);
-    images = gib_list_add_end(images, ret);
+    images = append_to_scrot_imlib(images, ret);
   }
   free(subdisp);
 
@@ -990,39 +1001,48 @@ scrot_grab_shot_multi(void)
 }
 
 Imlib_Image
-stalk_image_concat(gib_list * images)
+stalk_image_concat(Scrot_Imlib_List * images)
 {
   int tot_w = 0, max_h = 0, w, h;
   int x = 0;
-  gib_list *l, *item;
+  Scrot_Imlib_List *l, *item;
   Imlib_Image ret, im;
 
-  if (gib_list_length(images) == 0)
+  if (is_scrot_imlib_list_empty(images))
     return NULL;
 
   l = images;
   while (l) {
     im = (Imlib_Image) l->data;
-    h = gib_imlib_image_get_height(im);
-    w = gib_imlib_image_get_width(im);
+    imlib_context_set_image(im);
+    h = imlib_image_get_height();
+    w = imlib_image_get_width();
     if (h > max_h)
       max_h = h;
     tot_w += w;
     l = l->next;
   }
   ret = imlib_create_image(tot_w, max_h);
-  gib_imlib_image_fill_rectangle(ret, 0, 0, tot_w, max_h, 255, 0, 0, 0);
+  imlib_context_set_image(ret);
+  imlib_context_set_color(255, 0, 0, 0);
+  imlib_image_fill_rectangle(0, 0, tot_w, max_h);
   l = images;
   while (l) {
     im = (Imlib_Image) l->data;
     item = l;
     l = l->next;
-    h = gib_imlib_image_get_height(im);
-    w = gib_imlib_image_get_width(im);
-    gib_imlib_blend_image_onto_image(ret, im, 0, 0, 0, w, h, x, 0, w, h, 1, 0,
-                                     0);
+    imlib_context_set_image(im);
+    h = imlib_image_get_height();
+    w = imlib_image_get_width();
+    imlib_context_set_image(ret);
+    imlib_context_set_anti_alias(0);
+    imlib_context_set_dither(1);
+    imlib_context_set_blend(0);
+    imlib_context_set_angle(0);
+    imlib_blend_image_onto_image(im, 0, 0, 0, w, h, x, 0, w, h);
     x += w;
-    gib_imlib_free_image_and_decache(im);
+    imlib_context_set_image(im);
+    imlib_free_image_and_decache();
     free(item);
   }
   return ret;

--- a/src/note.c
+++ b/src/note.c
@@ -31,7 +31,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "scrot.h"
 
-
 scrotnote note;
 
 static Imlib_Font imfont = NULL;

--- a/src/note.h
+++ b/src/note.h
@@ -28,6 +28,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef NOTE_H
 #define NOTE_H
 
+#include <Imlib2.h>
 #include "options.h"
 
 /*

--- a/src/options.c
+++ b/src/options.c
@@ -442,7 +442,7 @@ options_parse_display(char *optarg)
      fprintf(stderr, "Unable to allocate display: %s", strerror(errno));
      exit(EXIT_FAILURE);
    }
-   strcpy(new_display, optarg);
+   strncpy(new_display, optarg, length);
    opt.display=new_display;
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -272,7 +272,7 @@ scrot_parse_option_array(int argc, char **argv)
            opt.delay = options_parse_required_number(optarg);
            break;
         case 'e':
-           opt.exec = gib_estrdup(optarg);
+           opt.exec = strdup(optarg);
            break;
         case 'm':
            opt.multidisp = 1;
@@ -326,7 +326,7 @@ scrot_parse_option_array(int argc, char **argv)
             options_parse_window_class_name(optarg);
         break;
         case 'S':
-           opt.script = gib_estrdup(optarg);
+           opt.script = strdup(optarg);
         break;
         case '?':
            exit(EXIT_FAILURE);
@@ -355,7 +355,7 @@ scrot_parse_option_array(int argc, char **argv)
                opt.thumb_file = name_thumbnail(opt.output_file);
          }
          else
-            gib_weprintf("unrecognised option %s\n", argv[optind++]);
+            fprintf(stderr, "unrecognised option %s\n", argv[optind++]);
       }
    }
 
@@ -372,7 +372,11 @@ name_thumbnail(char *name)
    size_t diff = 0;
 
    length = strlen(name) + 7;
-   new_title = gib_emalloc(length);
+   new_title = malloc(length);
+   if (! new_title) {
+     fprintf(stderr, "Unable to allocate thumbnail: %s", strerror(errno));
+     exit(EXIT_FAILURE);
+   }
 
    dot_pos = strrchr(name, '.');
    if (dot_pos)
@@ -433,8 +437,12 @@ options_parse_display(char *optarg)
    if (length > 256) {
      length = 256;
    }
-   new_display = gib_emalloc(length);
-   strncpy(new_display, optarg, length);
+   new_display = malloc(length);
+   if (! new_display) {
+     fprintf(stderr, "Unable to allocate display: %s", strerror(errno));
+     exit(EXIT_FAILURE);
+   }
+   strcpy(new_display, optarg);
    opt.display=new_display;
 }
 
@@ -476,7 +484,7 @@ options_parse_thumbnail(char *optarg)
 
 void options_parse_note(char *optarg)
 {
-   opt.note = gib_estrdup(optarg);
+   opt.note = strdup(optarg);
 
    if (opt.note == NULL) return;
 

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -63,13 +63,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <giblib/giblib.h>
 #include <stdbool.h>
 
-
 #include "scrot_config.h"
 #include "structs.h"
 #include "getopt.h"
 #include "debug.h"
 #include "note.h"
 #include "scrot_selection.h"
+#include "slist.h"
 
 #ifndef __GNUC__
 # define __attribute__(x)
@@ -102,7 +102,7 @@ char *im_printf(char *str, struct tm *tm,
                 Imlib_Image im);
 Imlib_Image scrot_grab_shot_multi(void);
 Imlib_Image scrot_grab_stack_windows(void);
-Imlib_Image stalk_image_concat(gib_list *images);
+Imlib_Image stalk_image_concat(Scrot_Imlib_List *images);
 
 void scrot_grab_mouse_pointer(const Imlib_Image image,
 		const int ix_off, const int iy_off);

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -60,6 +60,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <time.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <Imlib2.h>
 #include <stdbool.h>
 
 #include "scrot_config.h"

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -60,7 +60,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <time.h>
 #include <signal.h>
 #include <sys/wait.h>
-#include <giblib/giblib.h>
 #include <stdbool.h>
 
 #include "scrot_config.h"

--- a/src/slist.c
+++ b/src/slist.c
@@ -1,4 +1,4 @@
-/* structs.h
+/* slist.c
 
 Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
 

--- a/src/slist.c
+++ b/src/slist.c
@@ -55,7 +55,7 @@ Scrot_Imlib_List * walk_to_end_of_scrot_imlib_list(Scrot_Imlib_List *list) {
 }
 
 int is_scrot_imlib_list_empty(Scrot_Imlib_List *list) {
-  if (list == NULL || list->next == NULL)
+  if (list == NULL)
     return 1;
   else 
     return 0;

--- a/src/slist.c
+++ b/src/slist.c
@@ -55,7 +55,7 @@ Scrot_Imlib_List * walk_to_end_of_scrot_imlib_list(Scrot_Imlib_List *list) {
 }
 
 int is_scrot_imlib_list_empty(Scrot_Imlib_List *list) {
-  if (list == NULL && list->next == NULL)
+  if (list == NULL || list->next == NULL)
     return 1;
   else 
     return 0;

--- a/src/slist.c
+++ b/src/slist.c
@@ -1,0 +1,62 @@
+/* structs.h
+
+Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdlib.h>
+#include <Imlib2.h>
+#include "slist.h"
+
+Scrot_Imlib_List * append_to_scrot_imlib(Scrot_Imlib_List *head, Imlib_Image *data) {
+  
+  Scrot_Imlib_List *tail = walk_to_end_of_scrot_imlib_list(head);
+  Scrot_Imlib_List *appended = (Scrot_Imlib_List *) malloc(sizeof(Scrot_Imlib_List));
+  appended->data = data;
+  appended->next = NULL;
+
+  if (head == NULL) {
+    return appended;
+  } else {
+    tail->next = appended;
+  }
+
+  return head;
+}
+
+Scrot_Imlib_List * walk_to_end_of_scrot_imlib_list(Scrot_Imlib_List *list) {
+  if (list == NULL) return NULL;
+  if (list->next == NULL) return list;
+
+  while(list->next) {
+    list = list->next;
+  }
+
+  return list;
+}
+
+int is_scrot_imlib_list_empty(Scrot_Imlib_List *list) {
+  if (list == NULL && list->next == NULL)
+    return 1;
+  else 
+    return 0;
+}

--- a/src/slist.h
+++ b/src/slist.h
@@ -1,0 +1,42 @@
+/* structs.h
+
+Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef SCROT_SLIST_H
+#define SCROT_SLIST_H
+
+#include <Imlib2.h>
+#include <stdbool.h>
+
+typedef struct Scrot_Imlib_List {
+	Imlib_Image * data;
+	
+	struct Scrot_Imlib_List * next;
+} Scrot_Imlib_List;
+
+Scrot_Imlib_List * append_to_scrot_imlib(Scrot_Imlib_List *head, Imlib_Image *data);
+Scrot_Imlib_List * walk_to_end_of_scrot_imlib_list(Scrot_Imlib_List *list);
+int is_scrot_imlib_list_empty(Scrot_Imlib_List *list);
+
+#endif

--- a/src/slist.h
+++ b/src/slist.h
@@ -1,4 +1,4 @@
-/* structs.h
+/* slist.h
 
 Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,10 +1,21 @@
-/* imlib.c
+/* main.c
 
-Copyright 1999-2000 Tom Gilbert
+Copyright 1999-2000 Tom Gilbert <tom@linuxbrit.co.uk,
+                                  gilbertt@linuxbrit.co.uk,
+                                  scrot_sucks@linuxbrit.co.uk>
+Copyright 2009      James Cameron <quozl@us.netrek.org>
+Copyright 2010      Ibragimov Rinat <ibragimovrinat@mail.ru>
+Copyright 2017      Stoney Sauce <stoneysauce@gmail.com>
+Copyright 2019      Daniel T. Borelli <danieltborelli@gmail.com>
+Copyright 2019      Jade Auer <jade@trashwitch.dev>
+Copyright 2020      blockparole
+Copyright 2020      Cungsten Tarbide <ctarbide@tuta.io>
 Copyright 2020      daltomi <daltomi@disroot.org>
-Copyright 2020      ideal <idealities@gmail.com>
+Copyright 2020      Hinigatsu <hinigatsu@protonmail.com>
+Copyright 2020      nothub
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2020      spycapitan <spycapitan@protonmail.com>
+Copyright 2021      c0dev0id <sh+github@codevoid.de>
 Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -28,43 +39,29 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#include "scrot.h"
-#include "options.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "utils.h"
 
-Display *disp = NULL;
-Visual *vis = NULL;
-Screen *scr = NULL;
-Colormap cm;
-int depth;
-Window root = 0;
-
-
-void
-init_x_and_imlib(char *dispstr, int screen_num)
+extern char * _strdup(const char *input)
 {
-   disp = XOpenDisplay(dispstr);
-   if (!disp) {
-      fprintf(stderr, "Can't open X display. It *is* running, yeah? [");
-      fprintf(stderr, "%s", dispstr ? dispstr :
-              (getenv("DISPLAY") ? getenv("DISPLAY") : "NULL"));
-      fprintf(stderr, "]\n");
-      exit(EXIT_FAILURE);
-   }
+  if (! input) return NULL;
 
-   if (screen_num)
-      scr = ScreenOfDisplay(disp, screen_num);
-   else
-      scr = ScreenOfDisplay(disp, DefaultScreen(disp));
+  size_t length = strlen(input) + 1;
+  if (length == 0) return NULL;
 
-   vis = DefaultVisual(disp, XScreenNumberOfScreen(scr));
-   depth = DefaultDepth(disp, XScreenNumberOfScreen(scr));
-   cm = DefaultColormap(disp, XScreenNumberOfScreen(scr));
-   root = RootWindow(disp, XScreenNumberOfScreen(scr));
+  char *output = (char *) malloc(length);
 
-   imlib_context_set_drawable(root);
-   imlib_context_set_display(disp);
-   imlib_context_set_visual(vis);
-   imlib_context_set_colormap(cm);
-   imlib_context_set_color_modifier(NULL);
-   imlib_context_set_operation(IMLIB_OP_COPY);
+  if (output == NULL) {
+    fprintf(stderr,"Copy of %s failed on allocate", input);
+    return NULL;
+  }
+
+  strcpy(output, input);
+  output[length -1] = '\0';
+
+  fprintf(stderr, "String: %s", output);
+
+  return output;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -44,6 +44,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <stdio.h>
 #include "utils.h"
 
+#ifndef SCROT_HAVE_STRDUP
 extern char * _strdup(const char *input)
 {
   if (! input) return NULL;
@@ -55,7 +56,7 @@ extern char * _strdup(const char *input)
 
   if (output == NULL) {
     fprintf(stderr,"Copy of %s failed on allocate", input);
-    return NULL;
+    exit(EXIT_FAILURE);
   }
 
   strcpy(output, input);
@@ -63,3 +64,4 @@ extern char * _strdup(const char *input)
 
   return output;
 }
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -61,7 +61,5 @@ extern char * _strdup(const char *input)
   strcpy(output, input);
   output[length -1] = '\0';
 
-  fprintf(stderr, "String: %s", output);
-
   return output;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,21 +1,5 @@
-/* main.c
+/* utils.c
 
-Copyright 1999-2000 Tom Gilbert <tom@linuxbrit.co.uk,
-                                  gilbertt@linuxbrit.co.uk,
-                                  scrot_sucks@linuxbrit.co.uk>
-Copyright 2009      James Cameron <quozl@us.netrek.org>
-Copyright 2010      Ibragimov Rinat <ibragimovrinat@mail.ru>
-Copyright 2017      Stoney Sauce <stoneysauce@gmail.com>
-Copyright 2019      Daniel T. Borelli <danieltborelli@gmail.com>
-Copyright 2019      Jade Auer <jade@trashwitch.dev>
-Copyright 2020      blockparole
-Copyright 2020      Cungsten Tarbide <ctarbide@tuta.io>
-Copyright 2020      daltomi <daltomi@disroot.org>
-Copyright 2020      Hinigatsu <hinigatsu@protonmail.com>
-Copyright 2020      nothub
-Copyright 2020      Sean Brennan <zettix1@gmail.com>
-Copyright 2020      spycapitan <spycapitan@protonmail.com>
-Copyright 2021      c0dev0id <sh+github@codevoid.de>
 Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,36 @@
+/* structs.h
+
+Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef SCROT_UTILS_H
+#define SCROT_UTILS_H
+
+#include <string.h>
+
+#ifndef HAVE_STRDUP
+#define strdup(a) _strdup(a)
+extern char * _strdup(const char *input);
+#endif
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,4 +1,4 @@
-/* structs.h
+/* utils.h
 
 Copyright 2021      Christopher Nelson <christopher.nelson@languidnights.com>
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,8 +27,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define SCROT_UTILS_H
 
 #include <string.h>
+#include "scrot_config.h"
 
-#ifndef HAVE_STRDUP
+#ifndef SCROT_HAVE_STRDUP
 #define strdup(a) _strdup(a)
 extern char * _strdup(const char *input);
 #endif


### PR DESCRIPTION
giblib usage in scrot was primarily for simple wrappers around
imlib by setting context then calling/returning the wrapped
imlib_image_* calls. by reworking these calls, we can remove
the giblib dependency.

configure.ac: check for strdup
utils: implement strdup
slist: simple, dump singly-linked list
Makefile: add utils&slist
scrot: header updates
options: eprintf and strdup
main: remove simple wrappers with context + imlib calls