### PR TITLE
README.md: partial rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ scrot requires a few projects and libraries:
 - libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)
 - libxfixes [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxfixes)
 
-From a unix command line, building is simple:
+From a Unix command line, building is simple:
 ```
 $ ./autogen.sh
 $ ./configure
@@ -55,8 +55,7 @@ Cleaning up the build is also simple:
 $ make distclean
 ```
 
-You can return to a pristine source tree after running `make distclean`, or
-before running `./configure`:
+You can return to a pristine source tree before running `./configure`:
 ```
 $ ./autogen.sh clean
 ```
@@ -68,7 +67,7 @@ If you've built scrot from source, scrot needs to be installed from a root shell
 # make install
 ```
 
-Most users will want to look for the scrot package in their operating system:
+Debian users can install scrot from their package manager:
 ```
 $ sudo apt install scrot
 ```
@@ -78,4 +77,4 @@ $ sudo apt install scrot
 scrot was originally developed by Tom Gilbert.
 
 Currently, source code is maintained by volunteers. Newer versions are
-available at https://github.com/resurrecting-open-source-projects/scrot.
+available at https://github.com/resurrecting-open-source-projects/scrot

--- a/README.md
+++ b/README.md
@@ -2,62 +2,80 @@
 
 #### scrot - command line screen capture utility
 
+## What is scrot? ##
+
+scrot is a simple command line screen capture utility, it uses imlib2 to grab
+and save images.
+
+scrot has many useful features:
+  - Support for multiple image formats: JPG, PNG, GIF, and others.
+  - The screenshot's quality is configurable.
+  - It is possible to capture a specific window or a rectangular area on the
+    screen.
+
+Because scrot is a command line utility, it can easily be scripted and put to
+novel uses. For instance, scrot can be used to monitor an X server in absence.
+
+scrot is free software under the [MIT-advertising](COPYING) license.
+
 ## Help this project ##
 
-scrot needs your help. **If you are a programmer** and if you wants to help a
-nice project, this is your opportunity.
+scrot needs your help. **If you are a programmer** and want to help a nice
+project, this is your opportunity.
 
-scrot (SCReenshOT) was imported from some tarballs from Debian Project[1].
-After this, all patches found in Debian project and other places for this program
-were applied. All initial work was registered in ChangeLog file (version 0.9 and
-later releases). scrot is packaged in Debian[2] Project.
+The original scrot went unmaintained; the source of the last version, 0.8, was
+[imported from Debian](https://snapshot.debian.org/package/scrot/). After,
+patches from Debian and elsewhere were applied to create the 0.9 release-the
+details of our releases are registered in the [ChangeLog](ChangeLog) file.
+Now, scrot is maintained by volunteers under [Resurrecting Open Source Projects](https://github.com/resurrecting-open-source-projects).
 
-If you are interested to help SCReenshOT, read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+If you are interested in helping scrot, read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
-[1]: https://snapshot.debian.org/package/scrot/
-[2]: https://tracker.debian.org/pkg/scrot
+## Building ##
 
-## What is scrot (SCReenshOT)? ##
+scrot requires a few projects and libraries:
 
-scrot (SCReenshOT) is a simple command line screen capture utility that uses
-imlib2 to grab and save images. Multiple image formats are supported through
-imlib2's dynamic saver modules.
+- [autoconf](https://www.gnu.org/software/autoconf/autoconf.html) (build time only)
+- [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) (build time only)
+- [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
+- X [(e.g. X.Org)](https://www.x.org/wiki/)
+- libXcomposite [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxcomposite)
+- libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)
+- libxfixes [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxfixes)
 
-Some features of the scrot:
-  - support to multiple image formats (JPG, PNG, GIF, etc.).
-  - optimization of the screen shots image quality.
-  - capture a specific window or a rectangular area on the screen with the
-    help of switch.
+From a unix command line, building is simple:
+```
+$ ./autogen.sh
+$ ./configure
+$ make
+```
 
-scrot also can be used to monitor a desktop PC in admin absent and register
-unwanted activities.
+Cleaning up the build is also simple:
+```
+$ make distclean
+```
 
-Nowadays, scrot is maintained by volunteers.
+You can return to a pristine source tree after running `make distclean`, or
+before running `./configure`:
+```
+$ ./autogen.sh clean
+```
 
-## Build and Install ##
+## Installing ##
 
-scrot depends of the following libraries/artifacts to build:
+If you've built scrot from source, scrot needs to be installed from a root shell:
+```
+# make install
+```
 
-  - autoconf-archive
-  - imlib2
-  - libtool
-  - libxcomposite
-  - libxfixes
-
-To build and install, run the following commands:
-
-    $ ./autogen.sh
-    $ ./configure
-    $ make
-    # make install
-
-To return to original source code you can use '$ make distclean' command.
-
-On Debian systems you can use '# apt install scrot'.
+Most users will want to look for the scrot package in their operating system:
+```
+$ sudo apt install scrot
+```
 
 ## Author ##
 
-scrot was originally developed by Tom Gilbert under MIT-advertising license.
+scrot was originally developed by Tom Gilbert.
 
 Currently, source code is maintained by volunteers. Newer versions are
-available at https://github.com/resurrecting-open-source-projects/scrot
+available at https://github.com/resurrecting-open-source-projects/scrot.


### PR DESCRIPTION
Hi, I've polished the README.md file. 
The most inconsequential change is the correct English spelling and structure, but there is more to this patch:

I've removed redundant statements. For instance, repeating that scrot stands for (SCReenshOT) is jarring. 
The original text  also states that imlib2 is used to save images, procceeds to mention that imlib2 is used to support multiple image formats, and then lists support for multiple image formats among its features. That's a 3-way repetition.

There was one incorrect statement. scrot doesn't seem to depend on libtool directly. I'm not very good with autotools, so if this is wrong we can fix it.

I've clarified the build instructions. There was no mention that `make distclean` doesn't fully clean up the project, and that to do that `./autogen.sh clean` is needed. 

English punctuation is not so obvious and it was misused, so I've fixed it. 
For instance, a colon either precedes a listing or follows a complete clause and its use didn't always follow that.
The parenteses and the dot inside the parentheses in the list of supported image formats was also wrong.

That isn't everything, but that's the gist of it.