### PR TITLE
Remove compiler options

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@
 MAINTAINERCLEANFILES = Makefile.in
 
 AM_LDFLAGS        = -L/usr/X11R6/lib
-AM_CPPFLAGS       = -g -O3 -Wall -I/usr/X11R6/include \
+AM_CPPFLAGS       = -Wall -I/usr/X11R6/include \
 $(X_CFLAGS) -I$(prefix)/include -I$(includedir) -I. \
 -DPREFIX=\""$(prefix)"\" @IMLIB2_CFLAGS@
 LIBOBJS = @LIBOBJS@


### PR DESCRIPTION
 - Debug symbols flag : -g
 - Optimization flag  : -O3

It allows each maintainer of a particular distribution to indicate the
compilation mode that their standard requires, and it allows a
particular user to configure theirs.

Closes: #54