### PR TITLE
add the Cirrus CI system

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,112 @@
+# Copyright (C) 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of the Software and its documentation and acknowledgment shall be
+# given in the documentation and software packages that this Software was
+# used.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+common_template: &common_script
+  name: ${OS}-${CC}
+  build_script:
+    - ./autogen.sh
+    - ./configure
+    - make
+  on_failure:
+    autotools_artifacts:
+     path: config.log
+
+task:
+  matrix:
+    - container:
+        image: alpine:latest
+      env:
+        OS: alpine-latest
+    - container:
+        image: alpine:edge
+      env:
+        OS: alpine-edge
+  container:
+    kvm: true
+  env:
+    matrix:
+      - CC: clang
+      - CC: gcc
+  install_script:
+    - apk add autoconf autoconf-archive automake make pkgconfig clang gcc
+              xorg-server-dev libxcomposite-dev libxext-dev libxfixes-dev
+              imlib2-dev musl-dev
+  << : *common_script
+
+task:
+  matrix:
+    - container:
+        image: debian:oldstable
+      env:
+        OS: debian-oldstable
+    - container:
+        image: debian:stable
+      env:
+        OS: debian-stable
+    - container:
+        image: debian:testing
+      env:
+        OS: debian-testing
+    - container:
+        image: debian:unstable
+      env:
+        OS: debian-unstable
+  container:
+    kvm: true
+  env:
+    matrix:
+      - CC: clang
+      - CC: gcc
+  install_script:
+    - apt-get update
+    - apt-get install -y autoconf autoconf-archive make pkg-config clang gcc
+                         libx11-dev libxcomposite-dev libxext-dev libxfixes-dev
+                         libimlib2-dev
+  << : *common_script
+
+task:
+  freebsd_instance:
+    # Keep updated with the newest release from
+    # https://www.freebsd.org/releases/
+    image: freebsd-13-0-release-amd64
+  env:
+    OS: freebsd
+    matrix:
+      - CC: clang
+      - CC: gcc
+  install_script:
+    - pkg install -y autoconf autoconf-archive automake pkgconf gcc libX11
+                     libXcomposite libXext libXfixes imlib2
+  << : *common_script
+
+task:
+  macos_instance:
+    image: big-sur-base
+  env:
+    OS: macos
+    matrix:
+      - CC: clang
+      - CC: gcc
+  install_script:
+    - brew update
+    - brew install autoconf autoconf-archive automake make pkg-config gcc libx11
+                   libxcomposite libxext libxfixes imlib2
+  << : *common_script


### PR DESCRIPTION
This automates build testing in the following platforms:
  - Alpine Linux (musl Linux)
  - Debian Linux (glibc Linux)
  - FreeBSD
  - MacOS

Multiple branches of Debian are used to cover toolchains ranging from ancient to bleeding edge.
It would be very easy to add testing to this in the future, but
currently scrot has no tests.

If this is merged in, @eribertomota will have to add the
[Cirrus CI](https://cirrus-ci.org/) application to his github account to enable it.

Cirrus can be seen in action at this URL: https://cirrus-ci.com/github/guijan/scrot/add-cirrus