### PR TITLE
use the manual's synopsis as help text

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -13,6 +13,7 @@ Copyright 2019-2021 Daniel T. Borelli <daltomi@disroot.org>
 Copyright 2019      Jade Auer <jade@trashwitch.dev>
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -212,7 +213,6 @@ static void options_parse_window_class_name(const char* window_class_name)
         opt.window_class_name = strdup(window_class_name);
     }
 }
-
 
 static void
 scrot_parse_option_array(int argc, char **argv)
@@ -508,7 +508,6 @@ int options_cmp_window_class_name(const char* target_class_name)
     return !!(!strncmp(target_class_name, opt.window_class_name, MAX_LEN_WINDOW_CLASS_NAME - 1));
 }
 
-
 void
 show_version(void)
 {
@@ -517,105 +516,13 @@ show_version(void)
 }
 
 void
-show_mini_usage(void)
-{
-   printf("Usage : " SCROT_PACKAGE " [OPTIONS]... FILE\nUse " SCROT_PACKAGE
-          " --help for detailed usage information\n");
-   exit(0);
-}
-
-
-void
 show_usage(void)
 {
-   fprintf(stdout,
-           "Usage : " SCROT_PACKAGE " [OPTIONS]... [FILE]\n"
-           "  Where FILE is the target file for the screenshot.\n"
-           "  If FILE is not specified, a date-stamped file will be dropped in the\n"
-           "  current directory.\n" "  See man " SCROT_PACKAGE " for more details\n"
-           "  -h, --help                display this help and exit\n"
-           "  -v, --version             output version information and exit\n"
-           "  -D, --display             Set DISPLAY target other than current\n"
-           "  -a, --autoselect          non-interactively choose a rectangle of x,y,w,h\n"
-           "  -b, --border              When selecting a window, grab wm border too\n"
-           "                            Use with --select to raise the focus of the window.\n"
-           "  -c, --count               show a countdown before taking the shot\n"
-           "  -d, --delay NUM           wait NUM seconds before taking a shot\n"
-           "  -e, --exec APP            run APP on the resulting screenshot\n"
-           "  -q, --quality NUM         Image quality (1-100) high value means\n"
-           "                            high size, low compression. Default: 75.\n"
-           "                            For lossless compression formats, like png,\n"
-           "                            low quality means high compression.\n"
-           "  -m, --multidisp           For multiple heads, grab shot from each\n"
-           "                            and join them together.\n"
-           "  -s, --select              interactively choose a window or rectangle\n"
-           "                            with the mouse (use the arrow keys to resize)\n"
-           "  -u, --focused             use the currently focused window\n"
-           "  -t, --thumb NUM           generate thumbnail too. NUM is the percentage\n"
-           "                            of the original size for the thumbnail to be,\n"
-           "                            or the geometry in percent, e.g. 50x60 or 80x20.\n"
-           "  -z, --silent              Prevent beeping\n"
-           "  -p, --pointer             Capture the mouse pointer.\n"
-           "  -f, --freeze              Freeze the screen when the selection is used: --select\n"
-           "  -o, --overwrite           By default " SCROT_PACKAGE " does not overwrite the files, use this option to allow it.\n"
-           "  -l, --line                Indicates the style of the line when the selection is used: --select\n"
-           "                            See SELECTION STYLE\n"
-           "  -n, --note                Draw a text note.\n"
-           "                            See NOTE FORMAT\n"
-           "  -k, --stack               Capture stack/overlapped windows and join them together.\n"
-           "                            A running Composite Manager is needed.\n"
-           "  -C,  --class NAME         Window class name. Associative with options: -k\n"
-           "  -S,  --script CMD         Imlib2 script commands\n"
-           "\n" "  SPECIAL STRINGS\n"
-           "  Both the --exec and filename parameters can take format specifiers\n"
-           "  that are expanded by " SCROT_PACKAGE " when encountered.\n"
-           "  There are two types of format specifier. Characters preceded by a '%%'\n"
-           "  are interpreted by strftime(2). See man strftime for examples.\n"
-           "  These options may be used to refer to the current date and time.\n"
-           "  The second kind are internal to " SCROT_PACKAGE
-           "  and are prefixed by '$'\n"
-           "  The following specifiers are recognised:\n"
-           "                  $a hostname\n"
-           "                  $f image path/filename (ignored when used in the filename)\n"
-           "                  $m thumbnail path/filename\n"
-           "                  $n image name (ignored when used in the filename)\n"
-           "                  $s image size (bytes) (ignored when used in the filename)\n"
-           "                  $p image pixel size\n"
-           "                  $w image width\n"
-           "                  $h image height\n"
-           "                  $t image format (ignored when used in the filename)\n"
-           "                  $$  prints a literal '$'\n"
-           "                  \\n prints a newline (ignored when used in the filename)\n"
-           "  Example:\n" "          " SCROT_PACKAGE
-           " '%%Y-%%m-%%d_$wx$h_scrot.png' -e 'mv $f ~/images/shots/'\n"
-           "          Creates a file called something like 2000-10-30_2560x1024_scrot.png\n"
-           "          and moves it to your images directory.\n" "\n"
-           "\n" "  SELECTION STYLE\n"
-           "  When using --select you can indicate the style of the line with --line.\n"
-           "  The following specifiers are recognised:\n"
-           "                  style=(solid,dash),width=(range 1 to 8),color=\"value\",\n"
-           "                  opacity=(range 10 to 100),mode=(edge,classic)\n"
-           "  The default style is:\n"
-           "                  mode=classic,style=solid,width=1,opacity=100\n"
-           "  Mode 'edge' ignore    : style, --freeze\n"
-           "  Mode 'classic' ignore : opacity\n\n"
-           "  The 'opacity' specifier is only effective if a Composite Manager is running.\n\n"
-           "  For the color you can use a name or a hexadecimal value.\n"
-           "                  color=\"red\" or color=\"#ff0000\"\n"
-           "  Example:\n" "          " SCROT_PACKAGE
-           " --line style=dash,width=3,color=\"red\" --select\n\n"
-           "\n" "  NOTE FORMAT\n"
-           "  The following specifiers are recognised for the option --note\n"
-           "                  -f 'FontName/size'\n"
-           "                  -t 'text'\n"
-           "                  -x position (optional)\n"
-           "                  -y position (optional)\n"
-           "                  -c color(RGBA) (optional)\n"
-           "                  -a angle (optional)\n"
-           "  Example:\n" "          " SCROT_PACKAGE
-           " --note \"-f '/usr/share/fonts/TTF/DroidSans-Bold/40' -x 10 -y 20 -c 255,0,0,255 -t 'Hi'\"\n\n"
-           "This program is free software see the file COPYING for licensing info.\n"
-           "Copyright Tom Gilbert 2000\n"
-           "Email bugs to <scrot_sucks@linuxbrit.co.uk>\n");
+   fputs( /* Check that everything lines up after any changes. */
+   "usage:  "SCROT_PACKAGE" [-bcfhkmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]"
+   " \\\n"
+   "              [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \\\n"
+   "              [-t NUM | GEOM] [FILE]\n",
+   stdout);
    exit(0);
 }

--- a/src/options.c
+++ b/src/options.c
@@ -520,8 +520,8 @@ show_usage(void)
 {
    fputs( /* Check that everything lines up after any changes. */
    "usage:  "SCROT_PACKAGE" [-bcfhkmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]"
-   " \\\n"
-   "              [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \\\n"
+   "\n"
+   "              [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \n"
    "              [-t NUM | GEOM] [FILE]\n",
    stdout);
    exit(0);

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -78,7 +78,6 @@ typedef void (*sighandler_t) (int);
 
 void show_usage(void);
 void show_version(void);
-void show_mini_usage(void);
 void init_x_and_imlib(char *dispstr, int screen_num);
 char *chop_file_from_full_path(char *str);
 Imlib_Image scrot_grab_shot(void);


### PR DESCRIPTION
The old help text is outdated and a duplicate of the manual. This patch brings the help flag in line with the style popular among Suckless and BSD utilities:
```
$ src/scrot -h
usage:  scrot [-bcfhkmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] \
              [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \
              [-t NUM | GEOM] [FILE]
```

Here's an example of a suckless utility which follows the same style:
```
$ dmenu -h
usage: dmenu [-bfiv] [-l lines] [-p prompt] [-fn font] [-m monitor]
             [-nb color] [-nf color] [-sb color] [-sf color] [-w windowid]
```

And an OpenBSD utility with the same style:
```
$ signify -h
signify: unknown option -- h
usage:  signify -C [-q] [-p pubkey] [-t keytype] -x sigfile [file ...]
        signify -G [-n] [-c comment] -p pubkey -s seckey
        signify -S [-enz] [-x sigfile] -s seckey -m message
        signify -V [-eqz] [-p pubkey] [-t keytype] [-x sigfile] -m message
```

As you can see there are minor differences, signify uses 2 spaces between "usage:" and the command's name whereas dmenu uses 1, and I added an inverse slash before the newline to tell the user the next line is a continuation of the previous and dmenu didn't. There's no strict definition of this style.

This patch also removes the function show_mini_usage(), which does the
same thing and is dead code.

edit: brought the text in line with the current state of #101