### PR TITLE
remove unused __attribute__ macro

### DIFF
--- a/src/scrot.h
+++ b/src/scrot.h
@@ -70,10 +70,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot_selection.h"
 #include "slist.h"
 
-#ifndef __GNUC__
-# define __attribute__(x)
-#endif
-
 typedef void (*sighandler_t) (int);
 
 void show_usage(void);


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Variable-Attributes.html

This macro exists to turn a few GCC/Clang specific extensions into no-ops if on another compiler, but scrot isn't using any such extensions.