### PR TITLE
refactor options.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,7 @@ main(int argc,
   time_t t;
   struct tm *tm;
 
-  init_parse_options(argc, argv);
+  options_parse(argc, argv);
 
   init_x_and_imlib(opt.display, 0);
 

--- a/src/options.c
+++ b/src/options.c
@@ -40,27 +40,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "options.h"
 #include <assert.h>
 
-#define MAX_LEN_WINDOW_CLASS_NAME  80
+enum {MAX_LEN_WINDOW_CLASS_NAME = 80};
 
-static void scrot_parse_option_array(int argc, char **argv);
-scrotoptions opt;
-
-void
-init_parse_options(int argc, char **argv)
-{
-   /* Set default options */
-   memset(&opt, 0, sizeof(scrotoptions));
-
-   opt.quality = 75;
-   opt.overwrite = 0;
-   opt.line_style = LineSolid;
-   opt.line_width = 1;
-   opt.line_opacity = 100;
-   opt.line_mode = LINE_MODE_CLASSIC;
-
-   /* Parse the cmdline args */
-   scrot_parse_option_array(argc, argv);
-}
+scrotoptions opt = {
+    .quality = 75,
+    .line_style = LineSolid,
+    .line_width = 1,
+    .line_opacity = 100,
+    .line_mode = LINE_MODE_CLASSIC,
+};
 
 int
 options_parse_required_number(char *str)
@@ -227,8 +215,7 @@ static void options_parse_window_class_name(const char* window_class_name)
     }
 }
 
-static void
-scrot_parse_option_array(int argc, char **argv)
+void options_parse(int argc, char **argv)
 {
    static char stropts[] = "a:ofpbcd:e:hmq:st:uvzn:l:D:kC:S:";
 
@@ -428,8 +415,6 @@ options_parse_autoselect(char *optarg)
        fprintf(stderr, "invalid format for option -- 'autoselect'\n");
        exit(EXIT_FAILURE);
    }
-
-
 }
 
 void

--- a/src/options.h
+++ b/src/options.h
@@ -69,7 +69,7 @@ struct __scrotoptions
    int autoselect_w;
 };
 
-void init_parse_options(int argc, char **argv);
+void options_parse(int argc, char **argv);
 char *name_thumbnail(char *name);
 void options_parse_thumbnail(char *optarg);
 void options_parse_autoselect(char *optarg);


### PR DESCRIPTION
This patch is a small refactor for options.c and its header.
A function had its name changed so a call in main.c had to be changed.

By using designated initializers, we can do away with one function and abbreviate the code without being cryptic.
This also replaces a preprocessor use with an enum, and renames a function to use a shorter name.