### PR TITLE
assume c89 functions exist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AC_CHECK_TYPES([ptrdiff_t])
 
 # Required: Checks for library functions.
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([getopt_long getsubopt atexit gethostname memset select strchr strdup strerror strndup strpbrk strrchr strtol],,
+AC_CHECK_FUNCS([getopt_long getsubopt gethostname select strdup strerror strndup strtol],,
 	AC_MSG_ERROR([required functions are not present.]))
 
 m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])


### PR DESCRIPTION
This changes configure.ac to assume c89 functions exist.
Checking for them is pedantic and scrot is not compatible with C89 or pre-ANSI C, scrot is written in the newer C99 standard.

The more obtuse and roundabout the code is the harder it is to understand and maintain. Additionally, this will speed up the build a little as autotools is fairly slow.