### PR TITLE
style: convert src/imlib.c to the new style

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,20 +35,20 @@ The following libbsd integration efforts are in progress:
 We're currently in the process of complying with the new obligatory C style
 described in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-The following files are yet to be converted:
-- src/imlib.c
+The following are to be converted:
 - src/main.c
 - src/note.c
-- src/options.c
-- src/scrot_selection.c
-- src/selection_classic.c
-- src/selection_edge.c
-- src/slist.c
 - src/note.h
+- src/options.c
 - src/options.h
 - src/scrot.h
+- src/scrot_selection.c
 - src/scrot_selection.h
+- src/selection_classic.c
 - src/selection_classic.h
+- src/selection_edge.c
 - src/selection_edge.h
+- src/slist.c
 - src/slist.h
 - src/structs.h
+- ~~src/imlib.c~~

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -27,8 +27,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#include "options.h"
 #include "scrot.h"
+#include "options.h"
 
 Display *disp;
 Visual *vis;

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -27,43 +27,41 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#include "scrot.h"
 #include "options.h"
+#include "scrot.h"
 
-Display *disp = NULL;
-Visual *vis = NULL;
-Screen *scr = NULL;
+Display *disp;
+Visual *vis;
+Screen *scr;
 Colormap cm;
 int depth;
-Window root = 0;
+Window root;
 
-
-void
-init_x_and_imlib(char *dispstr, int screen_num)
+void init_x_and_imlib(char *dispstr, int screen_num)
 {
-   disp = XOpenDisplay(dispstr);
-   if (!disp) {
-      fprintf(stderr, "Can't open X display. It *is* running, yeah? [");
-      fprintf(stderr, "%s", dispstr ? dispstr :
-              (getenv("DISPLAY") ? getenv("DISPLAY") : "NULL"));
-      fprintf(stderr, "]\n");
-      exit(EXIT_FAILURE);
-   }
+    const char *badstr;
 
-   if (screen_num)
-      scr = ScreenOfDisplay(disp, screen_num);
-   else
-      scr = ScreenOfDisplay(disp, DefaultScreen(disp));
+    disp = XOpenDisplay(dispstr);
+    if (!disp) {
+	    if ((badstr = dispstr) == NULL)
+            if ((badstr = getenv("DISPLAY")) == NULL)
+                badstr = "(null)";
+        errx(EXIT_FAILURE, "can't open X display %s", badstr);
+    }
 
-   vis = DefaultVisual(disp, XScreenNumberOfScreen(scr));
-   depth = DefaultDepth(disp, XScreenNumberOfScreen(scr));
-   cm = DefaultColormap(disp, XScreenNumberOfScreen(scr));
-   root = RootWindow(disp, XScreenNumberOfScreen(scr));
+    if (!screen_num)
+        screen_num = DefaultScreen(disp);
+    scr = ScreenOfDisplay(disp, screen_num);
 
-   imlib_context_set_drawable(root);
-   imlib_context_set_display(disp);
-   imlib_context_set_visual(vis);
-   imlib_context_set_colormap(cm);
-   imlib_context_set_color_modifier(NULL);
-   imlib_context_set_operation(IMLIB_OP_COPY);
+    vis = DefaultVisual(disp, XScreenNumberOfScreen(scr));
+    depth = DefaultDepth(disp, XScreenNumberOfScreen(scr));
+    cm = DefaultColormap(disp, XScreenNumberOfScreen(scr));
+    root = RootWindow(disp, XScreenNumberOfScreen(scr));
+
+    imlib_context_set_drawable(root);
+    imlib_context_set_display(disp);
+    imlib_context_set_visual(vis);
+    imlib_context_set_colormap(cm);
+    imlib_context_set_color_modifier(NULL);
+    imlib_context_set_operation(IMLIB_OP_COPY);
 }


### PR DESCRIPTION
This patch also crosses out the src/imlib.c entry in TODO.md
I also sorted the list of files to be converted in TODO.md, I should've done that from the start.