### PR TITLE
remove obsolete autotools macros

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@
 #                                   scrot_sucks@linuxbrit.co.uk>
 # Copyright 2015-2019 Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
 # Copyright 2019-2020 Daniel T. Borelli <daltomi@disroot.org>
+# Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -26,14 +27,10 @@
 
 ## Process this file with automake to produce Makefile.in
 
-AUTOMAKE_OPTIONS = 1.4 foreign
+AUTOMAKE_OPTIONS = 1.10 foreign
 
 # A list of all the files in the current directory which can be regenerated
 MAINTAINERCLEANFILES = Makefile.in
-
-AM_LDFLAGS        = -L/usr/X11R6/lib -L/usr/lib -L/usr/local/lib
-AM_CPPFLAGS       = -I/usr/X11R6/include \
-$(X_CFLAGS) -I$(prefix)/include -I$(includedir) -I.
 
 man_MANS = man/scrot.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,12 +4,12 @@ AC_INIT([scrot], [1.6], [https://github.com/resurrecting-open-source-projects/sc
 		[],[https://github.com/resurrecting-open-source-projects/scrot])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE(dist-bzip2)
-AC_CONFIG_HEADER([src/config.h])
+AC_CONFIG_HEADERS([src/config.h])
 AX_PREFIX_CONFIG_H([src/scrot_config.h])
 
 # Checks for programs.
 AC_PROG_CC
-AM_PROG_CC_STDC
+AC_PROG_CC_C99
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
@@ -39,18 +39,9 @@ AC_SUBST([CPPFLAGS], ["$X11_CFLAGS $XCOMPOSITE_CFLAGS $XEXT_CFLAGS \
     $XFIXES_CFLAGS $IMLIB2_CFLAGS $LIBBSD_CFLAGS $CPPFLAGS"])
 
 # Checks for header files.
-AC_PATH_X
 AC_CHECK_HEADERS([stdint.h sys/time.h unistd.h])
 
-# Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_HEADER_STDBOOL
-AC_C_INLINE
-AC_C_CONST
-AC_TYPE_SIZE_T
-AC_CHECK_TYPES([ptrdiff_t])
-
 # Required: Checks for library functions.
-AC_FUNC_MALLOC
 AC_CHECK_FUNCS([getopt_long getsubopt atexit gethostname memset select strchr strdup strerror strndup strpbrk strrchr strtol],,
 	AC_MSG_ERROR([required functions are not present.]))
 


### PR DESCRIPTION
This patch:
- removes the the still hardcoded include directories in Makefile.am.
- updates the AC_CONFIGURE_HEADER macro to AC_CONFIGURE_HEADERS
Our CI says it's obsolete, I can't find the exact autotools announcement about this, but here's someone on a GNU website saying it's obsolete already in 2006:
https://savannah.gnu.org/support/?105403
- removes the obsolete AM_PROG_CC_STDC macro
Oddly, we were using this obsolete macro as well as its replacement (AC_PROG_CC) at the same time.
Look for AM_PROG_CC_STDC at https://autotools.io/forwardporting/automake.html
- adds the AC_PROG_CC_C99 macro
It sets the compiler to C99 mode if that isn't the default. This has the side effect of making the build work with ancient GCC versions in which C99 is supported and C89 is the default, e.g. GCC 4.2.
- removes the AC_PATH_X macro
We get X compiler flags from pkg-config now. Additionally, the X flags provided by this macro weren't actually used anyway.
- removes checks under the "checks for typedefs, structures, ..." comment
All of those except the stdbool one check for C89 features.
- removes the AC_FUNC_MALLOC macro
This macro is a workaround for malloc implementations that don't behave like the GNU one when a malloc(0) call is made (allocating 0 bytes is implementation-defined behavior in C). It's trivial to write correct C where this isn't a problem, and scrot has few malloc/calloc calls and already seems to do it.