### PR TITLE
CI: Use "apt-get"

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install_dependencies
-      run: sudo apt install autoconf-archive libimlib2-dev libxcomposite-dev libxfixes-dev libbsd-dev
+      run: sudo apt-get install autoconf-archive libimlib2-dev libxcomposite-dev libxfixes-dev libbsd-dev
     - name: first_build
       run: |
            ./autogen.sh


### PR DESCRIPTION
The [apt manpage](https://manpages.ubuntu.com/manpages/xenial/en/man8/apt.8.html) states that "apt-get" should be used in scripting.