### PR TITLE
New feature: hide selection area

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -48,9 +48,9 @@ OPTIONS
                             value represents higher quality and larger
                             file size. Default: 75.
   -S, --script CMD          CMD is an imlib2 script.
-  -s, --select              Interactively select a window or rectangle with the
+  -s, --select OPT          Interactively select a window or rectangle with the
                             mouse, use the arrow keys to resize. See the -l and
-                            -f options.
+                            -f options. OPT it's optional; see SELECTION ACTION
   -t, --thumb NUM | GEOM    Also generate a thumbnail. The argument is the
                             resolution of the thumbnail, it may be a percentage
                             NUM or a resolution GEOM. Examples: 10, 25, 320x240,
@@ -84,6 +84,16 @@ SPECIAL STRINGS
 
   This would create a PNG file with a name similar to 2000-10-30_2560x1024.png
   and optimize it with optipng(1).
+
+SELECTION ACTION
+  When using -s, optionally you can indicate the action to perform with the selection area.
+    capture         Capture the selection area, this action is by default.
+    hide            Hide the selection area by drawing a black area over it.
+
+  Example:
+
+    $ scrot --select=hide
+    $ scrot -shide
 
 SELECTION STYLE
   When using -s, you can indicate the style of the line with -l.

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -88,7 +88,8 @@ SPECIAL STRINGS
 SELECTION ACTION
   When using -s, optionally you can indicate the action to perform with the selection area.
     capture         Capture the selection area, this action is by default.
-    hide            Hide the selection area by drawing a black area over it.
+    hide            Hide the selection area by drawing an area of color over it.
+                    The color is the same as the selection line, see SELECTION STYLE
 
   Example:
 

--- a/src/main.c
+++ b/src/main.c
@@ -548,9 +548,13 @@ Imlib_Image scrotSelAndGrabImage(void)
         if (opt.select == SELECTION_MODE_CAPTURE)
             im = imlib_create_image_from_drawable(0, rx, ry, rw, rh, 1);
         else {
+            assert(opt.lineColor != NULL);
+            XColor color;
+
             im = imlib_create_image_from_drawable(0, 0, 0, scr->width, scr->height, 1);
             imlib_context_set_image(im);
-            imlib_context_set_color(0, 0, 0, 255);
+            scrotSelectionGetLineColor(&color);
+            imlib_context_set_color(color.red, color.green, color.blue, 255);
             imlib_image_fill_rectangle(rx, ry, rw, rh);
             pointerXOffset = 0;
             pointerYOffset = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -549,11 +549,12 @@ Imlib_Image scrotSelAndGrabImage(void)
             im = imlib_create_image_from_drawable(0, rx, ry, rw, rh, 1);
         else {
             assert(opt.lineColor != NULL);
+
             XColor color;
+            scrotSelectionGetLineColor(&color);
 
             im = imlib_create_image_from_drawable(0, 0, 0, scr->width, scr->height, 1);
             imlib_context_set_image(im);
-            scrotSelectionGetLineColor(&color);
             imlib_context_set_color(color.red, color.green, color.blue, 255);
             imlib_image_fill_rectangle(rx, ry, rw, rh);
             pointerXOffset = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -87,6 +87,29 @@ static int nonNegativeNumber(int number)
     return (number < 0) ? 0 : number;
 }
 
+static void optionsParseSelection(char* optarg)
+{
+    // the suboption it's optional
+    if (optarg == NULL) {
+        opt.select = SELECTION_MODE_CAPTURE;
+        return;
+    }
+
+    char const* value = strchr(optarg, '=');
+
+    if (value)
+        ++value;
+    else
+        value = optarg;
+
+    if (!strncmp(value, "capture", 7))
+        opt.select = SELECTION_MODE_CAPTURE;
+    else if (!strncmp(value, "hide", 4))
+        opt.select = SELECTION_MODE_HIDE;
+    else
+        errx(EXIT_FAILURE, "option --select: Unknown value for suboption '%s'", value);
+}
+
 static void optionsParseLine(char* optarg)
 {
     enum {
@@ -185,14 +208,13 @@ static void optionsParseWindowClassName(const char* windowClassName)
 
 void optionsParse(int argc, char** argv)
 {
-    static char stropts[] = "a:ofpbcd:e:hmq:st:uvzn:l:D:kC:S:";
+    static char stropts[] = "a:ofpbcd:e:hmq:s::t:uvzn:l:D:kC:S:";
 
     static struct option lopts[] = {
         /* actions */
         { "help", no_argument, 0, 'h' },
         { "version", no_argument, 0, 'v' },
         { "count", no_argument, 0, 'c' },
-        { "select", no_argument, 0, 's' },
         { "focused", no_argument, 0, 'u' },
         { "focussed", no_argument, 0, 'u' }, /* macquarie dictionary has both spellings */
         { "border", no_argument, 0, 'b' },
@@ -203,6 +225,7 @@ void optionsParse(int argc, char** argv)
         { "overwrite", no_argument, 0, 'o' },
         { "stack", no_argument, 0, 'k' },
         /* toggles */
+        { "select", optional_argument, 0, 's' },
         { "thumb", required_argument, 0, 't' },
         { "delay", required_argument, 0, 'd' },
         { "quality", required_argument, 0, 'q' },
@@ -244,7 +267,7 @@ void optionsParse(int argc, char** argv)
             opt.quality = optionsParseRequiredNumber(optarg);
             break;
         case 's':
-            opt.select = 1;
+            optionsParseSelection(optarg);
             break;
         case 'u':
             opt.focused = 1;

--- a/src/options.c
+++ b/src/options.c
@@ -90,7 +90,7 @@ static int nonNegativeNumber(int number)
 static void optionsParseSelection(char* optarg)
 {
     // the suboption it's optional
-    if (optarg == NULL) {
+    if (!optarg) {
         opt.select = SELECTION_MODE_CAPTURE;
         return;
     }

--- a/src/options.c
+++ b/src/options.c
@@ -87,7 +87,7 @@ static int nonNegativeNumber(int number)
     return (number < 0) ? 0 : number;
 }
 
-static void optionsParseSelection(char* optarg)
+static void optionsParseSelection(char const* optarg)
 {
     // the suboption it's optional
     if (!optarg) {

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -60,7 +60,7 @@ static void createCursors(void)
     assert(sel != NULL);
 
     if (opt.select == SELECTION_MODE_HIDE)
-        sel->curCross = XCreateFontCursor(disp, XC_target);
+        sel->curCross = XCreateFontCursor(disp, XC_spraycan);
     else
         sel->curCross = XCreateFontCursor(disp, XC_cross);
     sel->curAngleNE = XCreateFontCursor(disp, XC_ur_angle);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -59,7 +59,10 @@ static void createCursors(void)
 
     assert(sel != NULL);
 
-    sel->curCross = XCreateFontCursor(disp, XC_cross);
+    if (opt.select == SELECTION_MODE_HIDE)
+        sel->curCross = XCreateFontCursor(disp, XC_target);
+    else
+        sel->curCross = XCreateFontCursor(disp, XC_cross);
     sel->curAngleNE = XCreateFontCursor(disp, XC_ur_angle);
     sel->curAngleNW = XCreateFontCursor(disp, XC_ul_angle);
     sel->curAngleSE = XCreateFontCursor(disp, XC_lr_angle);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -184,7 +184,7 @@ struct SelectionRect* scrotSelectionGetRect(void)
     return &(*selectionGet())->rect;
 }
 
-Status scrotSelectionCreateNamedColor(char* nameColor, XColor* color)
+Status scrotSelectionCreateNamedColor(char const* nameColor, XColor* color)
 {
     assert(nameColor != NULL);
     assert(color != NULL);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -153,9 +153,6 @@ void scrotSelectionDestroy(void)
     XSync(disp, True);
     sel->destroy();
     selectionDeallocate();
-
-    if (opt.lineColor)
-        free(opt.lineColor);
 }
 
 void scrotSelectionDraw(void)
@@ -187,18 +184,29 @@ struct SelectionRect* scrotSelectionGetRect(void)
     return &(*selectionGet())->rect;
 }
 
-XColor scrotSelectionLineColor(void)
+Status scrotSelectionCreateNamedColor(char* nameColor, XColor* color)
 {
-    XColor color;
-    Status ret;
+    assert(nameColor != NULL);
+    assert(color != NULL);
 
-    ret = XAllocNamedColor(disp, XDefaultColormap(disp, DefaultScreen(disp)),
-        opt.lineColor, &color, &(XColor) {});
+    return XAllocNamedColor(disp, XDefaultColormap(disp, DefaultScreen(disp)),
+        nameColor, color, &(XColor) {});
+}
+
+void scrotSelectionGetLineColor(XColor* color)
+{
+    scrotSelectionSetDefaultColorLine();
+
+    Status const ret = scrotSelectionCreateNamedColor(opt.lineColor, color);
 
     if (!ret) {
         scrotSelectionDestroy();
         errx(EXIT_FAILURE, "Error allocate color:%s", strerror(BadColor));
     }
+}
 
-    return color;
+void scrotSelectionSetDefaultColorLine(void)
+{
+    if (!opt.lineColor)
+        opt.lineColor = "gray";
 }

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -69,4 +69,6 @@ void scrotSelectionDestroy(void);
 void scrotSelectionDraw(void);
 void scrotSelectionMotionDraw(int, int, int, int);
 struct SelectionRect* scrotSelectionGetRect(void);
-XColor scrotSelectionLineColor(void);
+void scrotSelectionGetLineColor(XColor*);
+Status scrotSelectionCreateNamedColor(char*, XColor*);
+void scrotSelectionSetDefaultColorLine(void);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -70,5 +70,5 @@ void scrotSelectionDraw(void);
 void scrotSelectionMotionDraw(int, int, int, int);
 struct SelectionRect* scrotSelectionGetRect(void);
 void scrotSelectionGetLineColor(XColor*);
-Status scrotSelectionCreateNamedColor(char*, XColor*);
+Status scrotSelectionCreateNamedColor(char const*, XColor*);
 void scrotSelectionSetDefaultColorLine(void);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -39,6 +39,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #define LINE_MODE_EDGE "edge"
 #define LINE_MODE_EDGE_LEN 4
 
+enum {
+    SELECTION_MODE_CAPTURE = 0,
+    SELECTION_MODE_HIDE = 1
+};
+
 struct SelectionRect {
     int x, y, w, h;
 };

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -52,11 +52,10 @@ void selectionClassicCreate(void)
     pc->gcValues.plane_mask = pc->gcValues.background ^ pc->gcValues.foreground;
     pc->gcValues.subwindow_mode = IncludeInferiors;
 
-    if (opt.lineColor) {
-        XColor const color = scrotSelectionLineColor();
-        pc->gcValues.foreground = color.pixel;
-    }
+    XColor color;
+    scrotSelectionGetLineColor(&color);
 
+    pc->gcValues.foreground = color.pixel;
     pc->gc = XCreateGC(disp, root,
         GCFunction | GCForeground | GCBackground | GCSubwindowMode,
         &pc->gcValues);

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -70,11 +70,8 @@ void selectionEdgeCreate(void)
 
     struct SelectionEdge* const pe = sel->edge;
 
-    // It is ok that in the "classic" mode it is to NULL, but it is not "edge" mode
-    if (!opt.lineColor)
-        opt.lineColor = strdup("gray");
-
-    XColor const color = scrotSelectionLineColor();
+    XColor color;
+    scrotSelectionGetLineColor(&color);
 
     XSetWindowAttributes attr;
     attr.background_pixel = color.pixel;


### PR DESCRIPTION
Allows you to create a black(*) area in a full screen capture to hide information.

(*) Edit: the color of the area of the same color of the selection line, the default color of the selection line is gray

Add optional argument for option --select
You can indicate the action to perform with the selection area:
```
   capture  Capture the selection area, this action is by default.
   hide     Hide the selection area by drawing a color area over it.

    Example:
        $ scrot --select=hide
        $ scrot -shide
        $ scrot -s=hide
```
![scrot-hide-selection](https://user-images.githubusercontent.com/73098402/129482370-707016cb-2cfc-470d-92f5-02e90404aa3e.png)
