### PR TITLE
Alert if mouse cursor image was not obtained

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -294,6 +294,11 @@ void scrotGrabMousePointer(const Imlib_Image image,
 {
     XFixesCursorImage* xcim = XFixesGetCursorImage(disp);
 
+    if (!xcim) {
+        warnx("Failed to get mouse cursor image.");
+        return;
+    }
+
     const unsigned short width = xcim->width;
     const unsigned short height = xcim->height;
     const int x = (xcim->x - xcim->xhot) - xOffset;


### PR DESCRIPTION
If Xlib cannot get the image of the mouse cursor we can do nothing
more than report and continue with the screenshot.

Bug fixed: segmentation fault