### PR TITLE
Update autoconf rules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,12 +4,11 @@ AC_INIT([scrot], [1.6], [https://github.com/resurrecting-open-source-projects/sc
 		[],[https://github.com/resurrecting-open-source-projects/scrot])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE(dist-bzip2)
-AC_CONFIG_HEADER([src/config.h])
+AC_CONFIG_HEADERS([src/config.h])
 AX_PREFIX_CONFIG_H([src/scrot_config.h])
 
 # Checks for programs.
 AC_PROG_CC
-AM_PROG_CC_STDC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 


### PR DESCRIPTION
On Debian Sid, using autoconf 2.71 (or >= 2.70), the following warnings
are shown:

```
configure.ac:7: warning: The macro `AC_CONFIG_HEADER' is obsolete.
configure.ac:7: You should run autoupdate.
./lib/autoconf/status.m4:719: AC_CONFIG_HEADER is expanded from...
configure.ac:7: the top level
configure.ac:12: warning: 'AM_PROG_CC_STDC': this macro is obsolete.
configure.ac:12: You should simply use the 'AC_PROG_CC' macro instead.
configure.ac:12: Also, your code should no longer depend upon 'am_cv_prog_cc_stdc',
configure.ac:12: but upon 'ac_cv_prog_cc_stdc'.
./lib/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
aclocal.m4:1249: AM_PROG_CC_STDC is expanded from...
configure.ac:12: the top level
```

This PR fixes all warnings.