### PR TITLE
Code style: use the identifier and not the type

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -238,7 +238,7 @@ void scrotCheckIfOverwriteFile(char** filename)
     if (ext)
         nalloc += extLength; // .ext
 
-    newName = calloc(nalloc, sizeof(char));
+    newName = calloc(nalloc, sizeof(*newName));
 
     if (ext) {
         // Exclude ext


### PR DESCRIPTION
As argument to the sizeof operator.