### PR TITLE
Replace insecure fuctions (strcpy,strcat,malloc)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,8 +25,8 @@ the web at [manpages.debian.org](https://manpages.debian.org/unstable/libbsd-dev
 BSD systems provide manuals for these functions in the default install.
 
 The following libbsd integration efforts are in progress:
-- Replace strncpy() and strcpy() calls with strlcpy().
-- Replace strcat() and strncat() calls with strlcat().
+- Replace strncpy() calls with strlcpy().
+- Replace strncat() calls with strlcat().
 - ~~Replace error exits with the err() family of functions.~~
 - ~~Replace local implementations of data structures with the sys/queue.h API.~~
 - Find places where other BSD functions can serve scrot well.

--- a/src/main.c
+++ b/src/main.c
@@ -721,28 +721,28 @@ char* imPrintf(char* str, struct tm* tm, char* filenameIM, char* filenameThumb, 
                 break;
             case 'f':
                 if (filenameIM)
-                    strcat(ret, filenameIM);
+                    strlcat(ret, filenameIM, sizeof(ret));
                 break;
             case 'm': /* t was already taken, so m as in mini */
                 if (filenameThumb)
-                    strcat(ret, filenameThumb);
+                    strlcat(ret, filenameThumb, sizeof(ret));
                 break;
             case 'n':
                 if (filenameIM) {
                     tmp = strrchr(filenameIM, '/');
                     if (tmp)
-                        strcat(ret, tmp + 1);
+                        strlcat(ret, tmp + 1, sizeof(ret));
                     else
-                        strcat(ret, filenameIM);
+                        strlcat(ret, filenameIM, sizeof(ret));
                 }
                 break;
             case 'w':
                 snprintf(buf, sizeof(buf), "%d", imlib_image_get_width());
-                strcat(ret, buf);
+                strlcat(ret, buf, sizeof(ret));
                 break;
             case 'h':
                 snprintf(buf, sizeof(buf), "%d", imlib_image_get_height());
-                strcat(ret, buf);
+                strlcat(ret, buf, sizeof(ret));
                 break;
             case 's':
                 if (filenameIM) {
@@ -751,26 +751,27 @@ char* imPrintf(char* str, struct tm* tm, char* filenameIM, char* filenameThumb, 
 
                         size = st.st_size;
                         snprintf(buf, sizeof(buf), "%d", size);
-                        strcat(ret, buf);
+                        strlcat(ret, buf, sizeof(ret));
                     } else
-                        strcat(ret, "[err]");
+                        strlcat(ret, "[err]", sizeof(ret));
                 }
                 break;
             case 'p':
                 snprintf(buf, sizeof(buf), "%d",
                     imlib_image_get_width() * imlib_image_get_height());
-                strcat(ret, buf);
+                strlcat(ret, buf, sizeof(ret));
                 break;
             case 't':
                 tmp = imlib_image_format();
                 if (tmp)
-                    strcat(ret, tmp);
+                    strlcat(ret, tmp, sizeof(ret));
                 break;
             case '$':
-                strcat(ret, "$");
+                strlcat(ret, "$", sizeof(ret));
                 break;
             default:
-                strncat(ret, c, 1);
+                snprintf(buf, sizeof(buf), "%.1s", c);
+                strlcat(ret, buf, sizeof(ret));
                 break;
             }
         } else if (*c == '\\') {
@@ -778,10 +779,11 @@ char* imPrintf(char* str, struct tm* tm, char* filenameIM, char* filenameThumb, 
             switch (*c) {
             case 'n':
                 if (filenameIM)
-                    strcat(ret, "\n");
+                    strlcat(ret, "\n", sizeof(ret));
                 break;
             default:
-                strncat(ret, c, 1);
+                snprintf(buf, sizeof(buf), "%.1s", c);
+                strlcat(ret, buf, sizeof(ret));
                 break;
             }
         } else {

--- a/src/options.c
+++ b/src/options.c
@@ -347,7 +347,7 @@ char* nameThumbnail(char* name)
     size_t diff = 0;
 
     length = strlen(name) + 7;
-    newTitle = malloc(length);
+    newTitle = calloc(length, sizeof(*newTitle));
 
     if (!newTitle)
         err(EXIT_FAILURE, "Unable to allocate thumbnail");
@@ -357,8 +357,8 @@ char* nameThumbnail(char* name)
         diff = (dotPos - name) / sizeof(char);
 
         strncpy(newTitle, name, diff);
-        strcat(newTitle, "-thumb");
-        strcat(newTitle, dotPos);
+        strlcat(newTitle, "-thumb", length);
+        strlcat(newTitle, dotPos, length);
     } else
         snprintf(newTitle, length, "%s-thumb", name);
 


### PR DESCRIPTION
Hello,
some of the strcpy/strcat replacements were patched into the OpenBSD scrot package. I rebased and extended the fixes a bit to cover all strcpy and strcat occurances and some strncat. I found a malloc that was not zeroed out and changed it to calloc. There is one strncpy and one strncat left I might look at later.

I did some rough testing and didn't see anything breaking in a noticable manner.