### PR TITLE
Do not assign black color to the foreground

### DIFF
--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -46,16 +46,21 @@ void selectionClassicCreate(void)
 
     struct SelectionClassic* pc = sel->classic;
 
+    unsigned long const whiteColor = XWhitePixel(disp, 0);
+    unsigned long const blackColor = XBlackPixel(disp, 0);
+
     pc->gcValues.function = GXxor;
-    pc->gcValues.foreground = XWhitePixel(disp, 0);
-    pc->gcValues.background = XBlackPixel(disp, 0);
+    pc->gcValues.foreground = whiteColor;
+    pc->gcValues.background = blackColor;
     pc->gcValues.plane_mask = pc->gcValues.background ^ pc->gcValues.foreground;
     pc->gcValues.subwindow_mode = IncludeInferiors;
 
     XColor color;
     scrotSelectionGetLineColor(&color);
 
-    pc->gcValues.foreground = color.pixel;
+    if (color.pixel != blackColor)
+        pc->gcValues.foreground = color.pixel;
+
     pc->gc = XCreateGC(disp, root,
         GCFunction | GCForeground | GCBackground | GCSubwindowMode,
         &pc->gcValues);


### PR DESCRIPTION
Only for classic selection mode.
When the line color is black, the selection area is not drawn.
This happens because the function attribute for GC is GXxor and
the foreground and background color should not be 0.

See: 95bea6b2fa (New feature: hide selection area)