### PR TITLE
Simplify color handling of the --note option

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -136,7 +136,7 @@ NOTE FORMAT
     -t  'text'
     -x  position (optional)
     -y  position (optional)
-    -c  color(RGBA) (optional)
+    -c  color(RGBA, range 0..255) (optional)
     -a  angle (optional)
 
   Example:

--- a/src/note.h
+++ b/src/note.h
@@ -1,8 +1,8 @@
 /* note.h
 
-Copyright 2019 Daniel T. Borelli <daltomi@disroot.org>
-Copyright 2021 Christopher R. Nelson <christopher.nelson@languidnights.com>
-Copyright 2021 Peter Wu <peterwu@hotmail.com>
+Copyright 2019-2021 Daniel T. Borelli <daltomi@disroot.org>
+Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
+Copyright 2021      Peter Wu <peterwu@hotmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -43,12 +43,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * */
 
-enum EColor {
-    ColorError = -1, /* error parser                        */
-    ColorOptional = 0, /* the user did not indicate the color */
-    ColorOK = 1, /* the user indicate the color         */
-};
-
 struct __ScrotNote {
     char* font; /* font name                   */
     char* text; /* text of the note            */
@@ -57,7 +51,6 @@ struct __ScrotNote {
     double angle; /* angle text (optional)       */
 
     struct Color { /*                 (optional)  */
-        enum EColor status;
         int r, /* red             */
             g, /* green           */
             b, /* blue            */


### PR DESCRIPTION
Handle color range internally and assign default values.
The manual is enough to know that an RGBA color has a range between 0 and 255.
Only warn the user if they entered a color with digits greater than RGBA.