### PR TITLE
Do not apply options that have already been applied

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -164,9 +164,6 @@ int main(int argc, char** argv)
 
             filenameThumb = imPrintf(opt.thumbFile, tm, NULL, NULL, thumbnail);
             scrotCheckIfOverwriteFile(&filenameThumb);
-
-            applyFilterIfRequired();
-
             imlib_save_image_with_error_return(filenameThumb, &imErr);
             if (imErr)
                 err(EXIT_FAILURE, "Saving thumbnail %s failed", filenameThumb);


### PR DESCRIPTION
When using the --note option and the --thumb option the note is drawn 2 times.