### PR TITLE
 Remove obsolete function: usleep

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -458,10 +458,13 @@ int scrotGetGeometry(Window target, int* rx, int* ry, int* rw, int* rh)
                Some windows never send the event, a time limit is placed.
             */
             XSelectInput(disp, target, FocusChangeMask);
+
+            struct timespec delay = {0, 10000000L}; // 10ms
+
             for (short i = 0; i < 30; ++i) {
                 if (XCheckIfEvent(disp, &ev, &scrotXEventVisibility, (XPointer)&target))
                     break;
-                usleep(2000);
+                nanosleep(&delay, NULL);
             }
         }
     }

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -55,10 +55,12 @@ static void waitUnmapWindowNotify(void)
 
     XUnmapWindow(disp, pe->wndDraw);
 
+    struct timespec delay = {0, 50000000L}; // 50ms
+
     for (short i = 0; i < 30; ++i) {
         if (XCheckIfEvent(disp, &ev, &xeventUnmap, (XPointer) & (pe->wndDraw)))
             break;
-        usleep(40000);
+        nanosleep(&delay, NULL);
     }
 }
 


### PR DESCRIPTION
This C routine is considered obsolete, nanosleep is used instead.