### PR TITLE
Increase delay to event unmap window

### DIFF
--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -55,7 +55,7 @@ static void waitUnmapWindowNotify(void)
 
     XUnmapWindow(disp, pe->wndDraw);
 
-    struct timespec delay = {0, 50000000L}; // 50ms
+    struct timespec delay = {0, 80000000L}; // 80ms
 
     for (short i = 0; i < 30; ++i) {
         if (XCheckIfEvent(disp, &ev, &xeventUnmap, (XPointer) & (pe->wndDraw)))


### PR DESCRIPTION
Selection mode: edge
In some selection areas, such as within a web browser, the selection border is captured.
To solve it, the delay is increased from 50ms to 80ms.