### PR TITLE
Fixed a couple of code style guideline violations

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -259,9 +259,10 @@ void scrotCheckIfOverwriteFile(char** filename)
     free(*filename);
     *filename = newName;
 
-    if (counter == maxCounter)
+    if (counter == maxCounter) {
         errx(EXIT_FAILURE, "scrot can no longer generate new file names.\n"
             "The last attempt is %s", newName);
+    }
 }
 
 int scrotMatchWindowClassName(Window target)

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@ Copyright 2021      c0dev0id <sh+github@codevoid.de>
 Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
 Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/note.c
+++ b/src/note.c
@@ -78,10 +78,10 @@ void scrotNoteNew(char* format)
     char* token = strpbrk(format, "-");
 
     if (!token || (strlen(token) == 1)) {
-    malformed:
+        malformed:
 
-        pfree(&format);
-        errx(EXIT_FAILURE, "Error --note option : Malformed syntax.");
+            pfree(&format);
+            errx(EXIT_FAILURE, "Error --note option : Malformed syntax.");
     }
 
     while (token) {

--- a/src/note.c
+++ b/src/note.c
@@ -3,6 +3,7 @@
 Copyright 2019-2021 Daniel T. Borelli <daltomi@disroot.org>
 Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/options.c
+++ b/src/options.c
@@ -148,9 +148,10 @@ static void optionsParseLine(char* optarg)
     while (*subopts != '\0') {
         switch (getsubopt(&subopts, token, &value)) {
         case Style:
-            if (!optionsParseIsString(value))
+            if (!optionsParseIsString(value)) {
                 errx(EXIT_FAILURE, "Missing value for suboption '%s'",
                     token[Style]);
+            }
 
             if (!strncmp(value, "dash", 4))
                 opt.lineStyle = LineOnOffDash;
@@ -161,42 +162,48 @@ static void optionsParseLine(char* optarg)
                     token[Style], value);
             break;
         case Width:
-            if (!optionsParseIsString(value))
+            if (!optionsParseIsString(value)) {
                 errx(EXIT_FAILURE, "Missing value for suboption '%s'",
                     token[Width]);
+            }
 
             opt.lineWidth = optionsParseRequiredNumber(value);
 
-            if (opt.lineWidth <= 0 || opt.lineWidth > 8)
+            if (opt.lineWidth <= 0 || opt.lineWidth > 8) {
                 errx(EXIT_FAILURE, "Value of the range (1..8) for "
                     "suboption '%s': %d", token[Width], opt.lineWidth);
+            }
             break;
         case Color:
-            if (!optionsParseIsString(value))
+            if (!optionsParseIsString(value)) {
                 errx(EXIT_FAILURE, "Missing value for suboption '%s'",
                     token[Color]);
+            }
 
             opt.lineColor = strdup(value);
             break;
         case Mode:
-            if (!optionsParseIsString(value))
+            if (!optionsParseIsString(value)) {
                 errx(EXIT_FAILURE, "Missing value for suboption '%s'",
                     token[Mode]);
+            }
 
             bool isValidMode = !strncmp(value, LINE_MODE_CLASSIC, LINE_MODE_CLASSIC_LEN);
 
             isValidMode = isValidMode || !strncmp(value, LINE_MODE_EDGE, LINE_MODE_EDGE_LEN);
 
-            if (!isValidMode)
+            if (!isValidMode) {
                 errx(EXIT_FAILURE, "Unknown value for suboption '%s': %s",
                     token[Mode], value);
+            }
 
             opt.lineMode = strdup(value);
             break;
         case Opacity:
-            if (!optionsParseIsString(value))
+            if (!optionsParseIsString(value)) {
                 errx(EXIT_FAILURE, "Missing value for suboption '%s'",
                     token[Opacity]);
+            }
             opt.lineOpacity = optionsParseRequiredNumber(value);
             break;
         default:
@@ -439,9 +446,10 @@ void optionsParseFileName(char* fileName)
 {
     opt.outputFile = fileName;
 
-    if (strlen(opt.outputFile) > MAX_OUTPUT_FILENAME)
+    if (strlen(opt.outputFile) > MAX_OUTPUT_FILENAME) {
         errx(EXIT_FAILURE,"output filename too long, must be "
             "less than %d characters", MAX_OUTPUT_FILENAME);
+    }
 }
 
 void optionsParseNote(char* optarg)


### PR DESCRIPTION
If conditions that have a body containing a single line, that's broken into multiple lines, should also use curly brackets.

However, there were a couple such if conditions without curly brackets so I just fixed that.