### PR TITLE
File option cleanup

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -84,8 +84,10 @@ int main(int argc, char** argv)
     if (!opt.outputFile) {
         opt.outputFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
         opt.thumbFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
-    } else
+    } else {
+        opt.thumbFile = nameThumbnail(opt.outputFile);
         scrotHaveFileExtension(opt.outputFile, &haveExtension);
+    }
 
     if (opt.focused)
         image = scrotGrabFocused();

--- a/src/main.c
+++ b/src/main.c
@@ -85,7 +85,8 @@ int main(int argc, char** argv)
         opt.outputFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
         opt.thumbFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
     } else {
-        opt.thumbFile = nameThumbnail(opt.outputFile);
+        if (opt.thumb)
+            opt.thumbFile = optionsNameThumbnail(opt.outputFile);
         scrotHaveFileExtension(opt.outputFile, &haveExtension);
     }
 

--- a/src/options.c
+++ b/src/options.c
@@ -435,13 +435,13 @@ void optionsParseThumbnail(char* optarg)
     }
 }
 
-void optionsParseFileName(char* fileName)
+void optionsParseFileName(char* optarg)
 {
-    opt.outputFile = fileName;
-
-    if (strlen(opt.outputFile) > MAX_OUTPUT_FILENAME)
+    opt.outputFile = strdup(optarg);
+    if (strlen(opt.outputFile) > MAX_OUTPUT_FILENAME) {
         errx(EXIT_FAILURE,"output filename too long, must be "
             "less than %d characters", MAX_OUTPUT_FILENAME);
+    }
 }
 
 void optionsParseNote(char* optarg)

--- a/src/options.c
+++ b/src/options.c
@@ -356,7 +356,7 @@ char* optionsNameThumbnail(const char* name)
     const char* const thumbSuffix = "-thumb";
     const size_t thumbSuffixLength = 7;
     const size_t newNameLength = strlen(name) + thumbSuffixLength;
-    char const* newName = calloc(1, newNameLength);
+    char* newName = calloc(1, newNameLength);
 
     if (!newName)
         err(EXIT_FAILURE, "Unable to allocate thumbnail");

--- a/src/options.c
+++ b/src/options.c
@@ -347,9 +347,6 @@ void optionsParse(int argc, char** argv)
             warnx("unrecognised option %s", argv[optind++]);
     }
 
-    if (opt.thumb && opt.outputFile)
-        opt.thumbFile = nameThumbnail(opt.outputFile);
-
     /* So that we can safely be called again */
     optind = 1;
 }

--- a/src/options.c
+++ b/src/options.c
@@ -351,7 +351,7 @@ void optionsParse(int argc, char** argv)
     optind = 1;
 }
 
-char* nameThumbnail(char* name)
+char* nameThumbnail(const char* name)
 {
     char* extension;
     const char* thumbSuffix = "-thumb";

--- a/src/options.c
+++ b/src/options.c
@@ -442,7 +442,7 @@ void optionsParseThumbnail(char* optarg)
     }
 }
 
-void optionsParseFileName(char* optarg)
+void optionsParseFileName(const char* optarg)
 {
     opt.outputFile = strdup(optarg);
     if (strlen(opt.outputFile) > MAX_OUTPUT_FILENAME) {

--- a/src/options.c
+++ b/src/options.c
@@ -351,28 +351,21 @@ void optionsParse(int argc, char** argv)
     optind = 1;
 }
 
-char* nameThumbnail(const char* name)
+char* optionsNameThumbnail(const char* name)
 {
-    char* extension;
-    const char* thumbSuffix = "-thumb";
-    char* newName;
-    size_t nameLength = 0;
-    size_t fullLength = 0;
-    const size_t thumbPrefixLength = 7;
-    size_t newNameLength = 0;
-
-    fullLength = strlen(name);
-    newNameLength = fullLength + thumbPrefixLength;
-    newName = malloc(newNameLength);
+    const char* const thumbSuffix = "-thumb";
+    const size_t thumbSuffixLength = 7;
+    const size_t newNameLength = strlen(name) + thumbSuffixLength;
+    char const* newName = calloc(1, newNameLength);
 
     if (!newName)
         err(EXIT_FAILURE, "Unable to allocate thumbnail");
 
-    extension = strrchr(name, '.');
+    const char* const extension = strrchr(name, '.');
+
     if (extension) {
         /* We add one so length includes '\0'*/
-        nameLength = ((extension - name) / sizeof(char) + 1);
-
+        const ptrdiff_t nameLength = (extension - name) + 1;
         strlcpy(newName, name, nameLength);
         strlcat(newName, thumbSuffix, newNameLength);
         strlcat(newName, extension, newNameLength);
@@ -445,11 +438,11 @@ void optionsParseThumbnail(char* optarg)
 
 void optionsParseFileName(const char* optarg)
 {
-    opt.outputFile = strdup(optarg);
-    if (strlen(opt.outputFile) > MAX_OUTPUT_FILENAME) {
+    if (strlen(optarg) > MAX_OUTPUT_FILENAME) {
         errx(EXIT_FAILURE,"output filename too long, must be "
             "less than %d characters", MAX_OUTPUT_FILENAME);
     }
+    opt.outputFile = strdup(optarg);
 }
 
 void optionsParseNote(char* optarg)

--- a/src/options.c
+++ b/src/options.c
@@ -370,7 +370,8 @@ char* nameThumbnail(const char* name)
 
     extension = strrchr(name, '.');
     if (extension) {
-        nameLength = (extension - name) / sizeof(char) + 1;
+        /* We add one so length includes '\0'*/
+        nameLength = ((extension - name) / sizeof(char) + 1);
 
         strlcpy(newName, name, nameLength);
         strlcat(newName, thumbSuffix, newNameLength);

--- a/src/options.c
+++ b/src/options.c
@@ -353,30 +353,33 @@ void optionsParse(int argc, char** argv)
 
 char* nameThumbnail(char* name)
 {
-    size_t length = 0;
-    char* newTitle;
-    char* dotPos;
-    size_t diff = 0;
+    char* extension;
+    const char* thumbSuffix = "-thumb";
+    char* newName;
+    size_t nameLength = 0;
+    size_t fullLength = 0;
+    const size_t thumbPrefixLength = 7;
+    size_t newNameLength = 0;
 
-    length = strlen(name) + 7;
-    newTitle = malloc(length);
+    fullLength = strlen(name);
+    newNameLength = fullLength + thumbPrefixLength;
+    newName = malloc(newNameLength);
 
-    if (!newTitle)
+    if (!newName)
         err(EXIT_FAILURE, "Unable to allocate thumbnail");
 
-    dotPos = strrchr(name, '.');
-    if (dotPos) {
-        diff = (dotPos - name) / sizeof(char);
+    extension = strrchr(name, '.');
+    if (extension) {
+        nameLength = (extension - name) / sizeof(char) + 1;
 
-        strncpy(newTitle, name, diff);
-        strcat(newTitle, "-thumb");
-        strcat(newTitle, dotPos);
+        strlcpy(newName, name, nameLength);
+        strlcat(newName, thumbSuffix, newNameLength);
+        strlcat(newName, extension, newNameLength);
     } else
-        snprintf(newTitle, length, "%s-thumb", name);
+        snprintf(newName, newNameLength, "%s%s", name, thumbSuffix);
 
-    return newTitle;
+    return newName;
 }
-
 
 void optionsParseAutoselect(char* optarg)
 {

--- a/src/options.h
+++ b/src/options.h
@@ -72,7 +72,7 @@ struct __ScrotOptions {
 };
 
 void optionsParse(int, char**);
-char* nameThumbnail(char*);
+char* nameThumbnail(const char*);
 void optionsParseFileName(char*);
 void optionsParseThumbnail(char*);
 void optionsParseAutoselect(char*);

--- a/src/options.h
+++ b/src/options.h
@@ -73,7 +73,7 @@ struct __ScrotOptions {
 
 void optionsParse(int, char**);
 char* nameThumbnail(const char*);
-void optionsParseFileName(char*);
+void optionsParseFileName(const char*);
 void optionsParseThumbnail(char*);
 void optionsParseAutoselect(char*);
 void optionsParseDisplay(char*);

--- a/src/options.h
+++ b/src/options.h
@@ -72,7 +72,7 @@ struct __ScrotOptions {
 };
 
 void optionsParse(int, char**);
-char* nameThumbnail(const char*);
+char* optionsNameThumbnail(const char*);
 void optionsParseFileName(const char*);
 void optionsParseThumbnail(char*);
 void optionsParseAutoselect(char*);


### PR DESCRIPTION
When I initially implemented the --file / -F option, the naming of the thumbnail was done in the options.c file, at the end of the options parsing function, by introducing an extra check if there is a filename and a thumbnail. However, I have felt that there must be a better way / place to do that.

I have since found out that in main.c after the parsing of the options, there is already a check if a filename exists and naming of both the thumbnail and the filename is done there. This felt like the perfect place.

So, from options.c, I removed:

```
if (opt.thumb && opt.outputFile)
        opt.thumbFile = nameThumbnail(opt.outputFile);
```

In main.c I changed this:

```
if (!opt.outputFile) {
        opt.outputFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
        opt.thumbFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
    } else
        scrotHaveFileExtension(opt.outputFile, &haveExtension);
```

To this:

```
if (!opt.outputFile) {
        opt.outputFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
        opt.thumbFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
    } else {
        opt.thumbFile = nameThumbnail(opt.outputFile);
        scrotHaveFileExtension(opt.outputFile, &haveExtension);
    }
```

However, there turned out to be a bug inside of nameThumbnail, that was breaking it when the call to it was moved to main.c This also fixes that, as well as converts the function to using strlcpy and strlcat instead of strncpy and strlcat.