### PR TITLE
ignore keyboard input option

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -2,7 +2,7 @@ NAME
   scrot - command line screen capture utility
 
 SYNOPSIS
-  scrot [-bcfhkmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] [-d SEC] [-e CMD]
+  scrot [-bcfhikmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] [-d SEC] [-e CMD]
         [-F FILE] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] [-t NUM | GEOM] [FILE]
 
 DESCRIPTION
@@ -33,6 +33,7 @@ OPTIONS
   -f, --freeze              Freeze the screen when -s is used.
   -F, --file                File name. See SPECIAL STRINGS.
   -h, --help                Display help and exit.
+  -i, --ignorekeyboard      Don't exit for keyboard input. ESC still exits.
   -k, --stack               Capture stack/overlapped windows and join them. A
                             running Composite Manager is needed.
   -l, --line STYLE          STYLE indicates the style of the line when the -s

--- a/src/options.c
+++ b/src/options.c
@@ -16,6 +16,7 @@ Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
 Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
+Copyright 2021      Wilson Smith <01wsmith+gh@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -224,7 +225,7 @@ static void optionsParseWindowClassName(const char* windowClassName)
 
 void optionsParse(int argc, char** argv)
 {
-    static char stropts[] = "a:ofpbcd:e:hmq:s::t:uvzn:l:D:kC:S:F:";
+    static char stropts[] = "a:ofipbcd:e:hmq:s::t:uvzn:l:D:kC:S:F:";
 
     static struct option lopts[] = {
         /* actions */
@@ -237,6 +238,7 @@ void optionsParse(int argc, char** argv)
         { "multidisp", no_argument, 0, 'm' },
         { "silent", no_argument, 0, 'z' },
         { "pointer", no_argument, 0, 'p' },
+        { "ignorekeyboard", no_argument, 0, 'i' },
         { "freeze", no_argument, 0, 'f' },
         { "overwrite", no_argument, 0, 'o' },
         { "stack", no_argument, 0, 'k' },
@@ -300,6 +302,9 @@ void optionsParse(int argc, char** argv)
             break;
         case 'p':
             opt.pointer = 1;
+            break;
+        case 'i':
+            opt.ignoreKeyboard = 1;
             break;
         case 'f':
             opt.freeze = 1;
@@ -480,7 +485,7 @@ void showVersion(void)
 void showUsage(void)
 {
     fputs(/* Check that everything lines up after any changes. */
-        "usage:  " SCROT_PACKAGE " [-bcfhkmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]"
+        "usage:  " SCROT_PACKAGE " [-bcfhikmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]"
         "\n"
         "              [-F FILE] [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \n"
         "              [-t NUM | GEOM] [FILE]\n",

--- a/src/options.h
+++ b/src/options.h
@@ -10,6 +10,7 @@ Copyright 2019-2021 Daniel T. Borelli <daltomi@disroot.org>
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
+Copyright 2021      Wilson Smith <01wsmith+gh@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -49,6 +50,7 @@ struct __ScrotOptions {
     int thumbWidth;
     int thumbHeight;
     int pointer;
+    int ignoreKeyboard;
     int freeze;
     int overwrite;
     int lineStyle;

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -3,6 +3,7 @@
 Copyright 2020-2021  Daniel T. Borelli <daltomi@disroot.org>
 Copyright 2021       Martin C <martincation@protonmail.com>
 Copyright 2021       Peter Wu <peterwu@hotmail.com>
+Copyright 2021       Wilson Smith <01wsmith+gh@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -264,13 +265,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect* selectionRect)
                 done = 1;
                 break;
             case KeyPress:
-                if (!isButtonPressed) {
-                key_abort_shot:
-                    warnx("Key was pressed, aborting shot");
-                    done = 2;
-                    break;
-                }
-
+            {
                 KeySym* keysym = NULL;
                 int keycode; /*dummy*/
 
@@ -278,6 +273,16 @@ bool scrotSelectionGetUserSel(struct SelectionRect* selectionRect)
 
                 if (!keysym)
                     break;
+
+                if (!isButtonPressed) {
+                key_abort_shot:
+                    if (!opt.ignoreKeyboard || *keysym == XK_Escape) {
+                        warnx("Key was pressed, aborting shot");
+                        done = 2;
+                    }
+                    XFree(keysym);
+                    break;
+                }
 
                 switch (*keysym) {
                 case XK_Right:
@@ -302,6 +307,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect* selectionRect)
                 XFree(keysym);
                 scrotSelectionMotionDraw(rx, ry, ev.xbutton.x, ev.xbutton.y);
                 break;
+            }
             case KeyRelease:
                 /* ignore */
                 break;


### PR DESCRIPTION
New option `--ignorekeyboard` (`-i`): do not exit when a keyboard button is pressed.

I added this because repeat keyboard events (from starting scrot via a keybind) were causing scrot to immediately close.

Now, when the `-i` argument is passed, the only key that causes scrot to quit is Escape.