### PR TITLE
add util.{c,h} with estrdup function and use it

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,4 +41,5 @@ options.c options.h imlib.c structs.h note.c note.h \
 scrot_selection.c scrot_selection.h \
 selection_classic.c selection_classic.h \
 selection_edge.c selection_edge.h \
+util.c util.h \
 slist.h

--- a/src/main.c
+++ b/src/main.c
@@ -82,8 +82,8 @@ int main(int argc, char** argv)
     atexit(uninitXAndImlib);
 
     if (!opt.outputFile) {
-        opt.outputFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
-        opt.thumbFile = strdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
+        opt.outputFile = estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
+        opt.thumbFile = estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
     } else {
         if (opt.thumb)
             opt.thumbFile = optionsNameThumbnail(opt.outputFile);
@@ -607,7 +607,7 @@ char* imPrintf(char* str, struct tm* tm, char* filenameIM, char* filenameThumb, 
             ret[length + 1] = '\0';
         }
     }
-    return strdup(ret);
+    return estrdup(ret);
 }
 
 Window scrotGetClientWindow(Display* display, Window target)
@@ -737,7 +737,7 @@ Imlib_Image scrotGrabShotMulti(void)
 
     initializeScrotList(images);
 
-    subDisp = strdup(DisplayString(disp));
+    subDisp = estrdup(DisplayString(disp));
 
     for (i = 0; i < screens; i++) {
         dispStr = strchr(subDisp, ':');

--- a/src/options.c
+++ b/src/options.c
@@ -192,7 +192,7 @@ static void optionsParseSelection(char const* optarg)
 
         checkMaxInputFileName(value);
 
-        opt.selection.paramStr = strdup(value);
+        opt.selection.paramStr = estrdup(value);
     }
 }
 
@@ -254,7 +254,7 @@ static void optionsParseLine(char* optarg)
                     token[Color]);
             }
 
-            opt.lineColor = strdup(value);
+            opt.lineColor = estrdup(value);
             break;
         case Mode:
             if (!optionsParseIsString(value)) {
@@ -271,7 +271,7 @@ static void optionsParseLine(char* optarg)
                     token[Mode], value);
             }
 
-            opt.lineMode = strdup(value);
+            opt.lineMode = estrdup(value);
             break;
         case Opacity:
             if (!optionsParseIsString(value)) {
@@ -378,7 +378,7 @@ void optionsParse(int argc, char** argv)
             opt.delay = nonNegativeNumber(optionsParseRequiredNumber(optarg));
             break;
         case 'e':
-            opt.exec = strdup(optarg);
+            opt.exec = estrdup(optarg);
             break;
         case 'm':
             opt.multidisp = 1;
@@ -433,7 +433,7 @@ void optionsParse(int argc, char** argv)
             optionsParseWindowClassName(optarg);
             break;
         case 'S':
-            opt.script = strdup(optarg);
+            opt.script = estrdup(optarg);
             break;
         case 'F':
             optionsParseFileName(optarg);
@@ -556,12 +556,12 @@ void optionsParseThumbnail(char* optarg)
 void optionsParseFileName(const char* optarg)
 {
     checkMaxOutputFileName(optarg);
-    opt.outputFile = strdup(optarg);
+    opt.outputFile = estrdup(optarg);
 }
 
 void optionsParseNote(char* optarg)
 {
-    opt.note = strdup(optarg);
+    opt.note = estrdup(optarg);
 
     if (!opt.note)
         return;

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -67,6 +67,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot_selection.h"
 #include "slist.h"
 #include "structs.h"
+#include "util.h"
 
 typedef void (*signalHandler)(int);
 

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,34 @@
+/* util.c
+
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include "scrot.h"
+
+char *estrdup(const char *str)
+{
+    char *p;
+    if ((p = strdup(str)) == NULL)
+        err(1, "strdup");
+    return p;
+}

--- a/src/util.c
+++ b/src/util.c
@@ -1,6 +1,6 @@
 /* util.c
 
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/util.c
+++ b/src/util.c
@@ -29,6 +29,6 @@ char *estrdup(const char *str)
 {
     char *p;
     if ((p = strdup(str)) == NULL)
-        err(1, "strdup");
+        err(EXIT_FAILURE, "strdup");
     return p;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,6 @@
 /* util.h
 
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,28 @@
+/* util.h
+
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#pragma once
+
+char *estrdup(const char *);


### PR DESCRIPTION
This patch adds an estrdup() fuction which is merely a strdup() which never returns NULL because it terminates execution on error. It replaces strdup() calls with the new function, none of the current strdup() calls check if the returned pointer is NULL.