### PR TITLE
check for more libbsd functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,8 @@ PKG_CHECK_MODULES([IMLIB2], [imlib2])
 
 AC_ARG_WITH([libbsd],
     AS_HELP_STRING([--without-libbsd], [Error when BSD functions are not found]))
-AC_CHECK_FUNCS([strlcpy strlcat err errx],, [LIBBSD_NEEDED=yes])
+AC_CHECK_FUNCS([strlcpy strlcat err errx warn warnx],, [LIBBSD_NEEDED=yes])
+AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes])
 AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
     AS_IF([test "x$with_libbsd" = "xno"], [
         AC_MSG_ERROR([BSD functions not found and --without-libbsd was used])


### PR DESCRIPTION
This patch adds checks for the presence of the warn() and warnx() functions, and it also adds a check for the presence of the sys/queue.h header.