### PR TITLE
C99 forbids empty initializer braces, fill them

### DIFF
--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -195,7 +195,7 @@ Status scrotSelectionCreateNamedColor(char const* nameColor, XColor* color)
     assert(color != NULL);
 
     return XAllocNamedColor(disp, XDefaultColormap(disp, DefaultScreen(disp)),
-        nameColor, color, &(XColor) {});
+        nameColor, color, &(XColor){0});
 }
 
 void scrotSelectionGetLineColor(XColor* color)


### PR DESCRIPTION
An empty initializer list is a GNU extension. The Standard C way of initializing a struct with nulls is to initialize the first member with a 0, which implicitly null-initializes all the other members of the struct.

I've been playing with compiler flags and compiling scrot with several compilers in the hopes I catch something, this unnecessary usage of a GNU extension came up.