### PR TITLE
remove src/stamp-h.in

### DIFF
--- a/src/stamp-h.in
+++ b/src/stamp-h.in
@@ -1,1 +1,0 @@
-timestamp


### PR DESCRIPTION
Autotools documentation has an "Automatic Remaking" chapter, as you can see at: https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/html_node/Automatic-Remaking.html

In it, there's a snippet about using a "stamp-h.in" file to "automatically update the configuration information when you change the configuration files" to quote the page, by adding a few rules to Makefile.in.

Except we don't have such rules in our Makefile.in, so we're not using that file. The file dates back to old scrot so maybe it was in use then, but it's not now.
This patch removes src/stamp-h.in.
I've skimmed the source tree a few times and I think that with this all the unused files will have been removed.