### PR TITLE
untangle headers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,9 +46,9 @@ task:
       - CC: clang
       - CC: gcc
   install_script:
-    - apk add autoconf autoconf-archive automake make pkgconfig clang gcc
-              xorg-server-dev libxcomposite-dev libxext-dev libxfixes-dev
-              imlib2-dev musl-dev bsd-compat-headers
+    - apk add autoconf automake make pkgconfig clang gcc xorg-server-dev
+              libxcomposite-dev libxext-dev libxfixes-dev imlib2-dev musl-dev
+              bsd-compat-headers
   << : *common_script
 
 task:
@@ -69,8 +69,8 @@ task:
       - CC: gcc
   install_script:
     - apt-get update
-    - apt-get install -y autoconf autoconf-archive make pkg-config clang gcc
-                         libx11-dev libxcomposite-dev libxext-dev libxfixes-dev
+    - apt-get install -y autoconf make pkg-config clang gcc libx11-dev
+                         libxcomposite-dev libxext-dev libxfixes-dev
                          libimlib2-dev libbsd-dev
   << : *common_script
 
@@ -85,8 +85,8 @@ task:
       - CC: clang
       - CC: gcc
   install_script:
-    - pkg install -y autoconf autoconf-archive automake pkgconf gcc libX11
-                     libXcomposite libXext libXfixes imlib2
+    - pkg install -y autoconf automake pkgconf gcc libX11 libXcomposite libXext
+                     libXfixes imlib2
   << : *common_script
 
 task:
@@ -99,6 +99,6 @@ task:
       - CC: gcc
   install_script:
     - brew update
-    - brew install autoconf autoconf-archive automake make pkg-config gcc libx11
-                   libxcomposite libxext libxfixes imlib2
+    - brew install autoconf automake make pkg-config gcc libx11 libxcomposite
+                   libxext libxfixes imlib2
   << : *common_script

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install_dependencies
-      run: sudo apt install autoconf-archive libimlib2-dev libxcomposite-dev libxfixes-dev libbsd-dev
+      run: sudo apt install libimlib2-dev libxcomposite-dev libxfixes-dev libbsd-dev
     - name: first_build
       run: |
            ./autogen.sh

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ If you are interested in helping scrot, read the [CONTRIBUTING.md](CONTRIBUTING.
 scrot requires a few projects and libraries:
 
 - [autoconf](https://www.gnu.org/software/autoconf/autoconf.html) (build time only)
-- [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) (build time only)
 - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (build time only)
 - [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
 - [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --without-libbsd; make` fails)

--- a/configure.ac
+++ b/configure.ac
@@ -2,10 +2,9 @@ dnl Process this file with autoconf to create configure.
 
 AC_INIT([scrot], [1.7], [https://github.com/resurrecting-open-source-projects/scrot/issues],
 		[],[https://github.com/resurrecting-open-source-projects/scrot])
-AC_CONFIG_SRCDIR([src/main.c])
+AC_CONFIG_SRCDIR([src/scrot.c])
 AM_INIT_AUTOMAKE(dist-bzip2)
 AC_CONFIG_HEADERS([src/config.h])
-AX_PREFIX_CONFIG_H([src/scrot_config.h])
 
 # Checks for programs.
 AC_PROG_CC
@@ -44,8 +43,6 @@ AC_CHECK_HEADERS([stdint.h sys/time.h unistd.h])
 # Required: Checks for library functions.
 AC_CHECK_FUNCS([getopt_long getsubopt gethostname select strdup strerror strndup strtol],,
 	AC_MSG_ERROR([required functions are not present.]))
-
-m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,10 +36,12 @@ bin_PROGRAMS  = scrot
 
 scrot_CPPFLAGS = @CPPFLAGS@
 scrot_LDADD    = @LIBS@
-scrot_SOURCES  = main.c scrot.h \
-options.c options.h imlib.c note.c note.h \
-scrot_selection.c scrot_selection.h \
+scrot_SOURCES  = scrot.c scrot.h        \
+imlib.c imlib.h                         \
+note.c note.h                           \
+options.c options.h                     \
+scrot_selection.c scrot_selection.h     \
 selection_classic.c selection_classic.h \
-selection_edge.c selection_edge.h \
-util.c util.h \
-slist.h
+selection_edge.c selection_edge.h       \
+slist.h                                 \
+util.c util.h

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -38,26 +38,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "imlib.h"
 
 /* Imlib stuff */
-Display* disp;
-Visual* vis;
+Display *disp;
+Visual *vis;
 Colormap cm;
 int depth;
 
 /* Thumbnail sizes */
 Window root;
-Screen* scr;
+Screen *scr;
 
-void initXAndImlib(char* dispStr, int screenNumber)
+void initXAndImlib(char *dispStr, int screenNumber)
 {
     disp = XOpenDisplay(dispStr);
     if (!disp) {
 
-        char const* const format = "Can't open X display. It *is* running, "
+        const char *const format = "Can't open X display. It *is* running, "
             "yeah? [%s]";
 
-        char const* env = NULL;
+        const char *env = NULL;
 
-        char const* const value = dispStr ? dispStr :
+        const char *const value = dispStr ? dispStr :
             (env = getenv("DISPLAY")) ? env : "NULL";
 
         errx(EXIT_FAILURE, format, value);

--- a/src/imlib.c
+++ b/src/imlib.c
@@ -6,6 +6,7 @@ Copyright 2020      ideal <idealities@gmail.com>
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -28,15 +29,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#include "options.h"
-#include "scrot.h"
+#include <err.h>
+#include <stdlib.h>
 
-Display* disp = NULL;
-Visual* vis = NULL;
-Screen* scr = NULL;
+#include <Imlib2.h>
+#include <X11/Xlib.h>
+
+#include "imlib.h"
+
+/* Imlib stuff */
+Display* disp;
+Visual* vis;
 Colormap cm;
 int depth;
-Window root = 0;
+
+/* Thumbnail sizes */
+Window root;
+Screen* scr;
 
 void initXAndImlib(char* dispStr, int screenNumber)
 {

--- a/src/imlib.h
+++ b/src/imlib.h
@@ -1,7 +1,5 @@
-/* scrot_selection_edge.h
+/* imlib.h
 
-Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
-Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,14 +23,17 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-/*
-    This file is part of the scrot project.
-    Part of the code comes from the scrot.c file and maintains its authorship.
-*/
+/* Part of the code comes from the scrot.c file and maintains its authorship. */
 
 #pragma once
 
-void selectionEdgeCreate(void);
-void selectionEdgeDestroy(void);
-void selectionEdgeDraw(void);
-void selectionEdgeMotionDraw(int, int, int, int);
+#include <X11/Xlib.h>
+
+extern Display* disp;
+extern Visual* vis;
+extern Colormap cm;
+extern int depth;
+extern Window root;
+extern Screen* scr;
+
+void initXAndImlib(char *, int);

--- a/src/imlib.h
+++ b/src/imlib.h
@@ -29,11 +29,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <X11/Xlib.h>
 
-extern Display* disp;
-extern Visual* vis;
+extern Display *disp;
+extern Visual *vis;
 extern Colormap cm;
 extern int depth;
 extern Window root;
-extern Screen* scr;
+extern Screen *scr;
 
 void initXAndImlib(char *, int);

--- a/src/note.c
+++ b/src/note.c
@@ -1,7 +1,7 @@
 /* note.c
 
 Copyright 2019-2021 Daniel T. Borelli <danieltborelli@gmail.com>
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 
@@ -47,23 +47,21 @@ enum { // default color
 struct ScrotNote note;
 
 static Imlib_Font imFont = NULL;
-
 static void loadFont(void);
-
 static char* parseText(char**, char* const);
 
-static inline void pfree(char** ptr)
+static void pfree(char** ptr)
 {
     free(*ptr);
     *ptr = NULL;
 }
 
-static inline void nextSpace(char** token)
+static void nextSpace(char** token)
 {
     while (*++*token == ' ' && **token != '\0') { }
 }
 
-static inline void nextNotSpace(char** token)
+static void nextNotSpace(char** token)
 {
     while (*++*token != ' ' && **token != '\0') { }
 }
@@ -211,7 +209,7 @@ void scrotNoteDraw(Imlib_Image im)
     imlib_text_draw(note.x, note.y, note.text);
 }
 
-void loadFont(void)
+static void loadFont(void)
 {
     imFont = imlib_load_font(note.font);
 
@@ -222,7 +220,7 @@ void loadFont(void)
     }
 }
 
-char* parseText(char** token, char* const end)
+static char* parseText(char** token, char* const end)
 {
     assert(NULL != *token);
     assert(NULL != end);

--- a/src/note.c
+++ b/src/note.c
@@ -26,12 +26,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-/* This file is part of the scrot project. */
-
 #include <assert.h>
-#include <stdint.h>
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "scrot.h"
+#include <Imlib2.h>
+
+#include "note.h"
+#include "options.h"
 
 enum { // default color
     DEF_COLOR_RED = 0,

--- a/src/note.c
+++ b/src/note.c
@@ -48,25 +48,25 @@ struct ScrotNote note;
 
 static Imlib_Font imFont = NULL;
 static void loadFont(void);
-static char* parseText(char**, char* const);
+static char *parseText(char **, char *const);
 
-static void pfree(char** ptr)
+static void pfree(char **ptr)
 {
     free(*ptr);
     *ptr = NULL;
 }
 
-static void nextSpace(char** token)
+static void nextSpace(char **token)
 {
     while (*++*token == ' ' && **token != '\0') { }
 }
 
-static void nextNotSpace(char** token)
+static void nextNotSpace(char **token)
 {
     while (*++*token != ' ' && **token != '\0') { }
 }
 
-void scrotNoteNew(char* format)
+void scrotNoteNew(char *format)
 {
     scrotNoteFree();
 
@@ -76,9 +76,9 @@ void scrotNoteNew(char* format)
           DEF_COLOR_BLUE, DEF_COLOR_ALPHA }
     };
 
-    char* const end = format + strlen(format);
+    char *const end = format + strlen(format);
 
-    char* token = strpbrk(format, "-");
+    char *token = strpbrk(format, "-");
 
     if (!token || (strlen(token) == 1)) {
         malformed:
@@ -89,8 +89,8 @@ void scrotNoteNew(char* format)
 
     while (token) {
         const char type = *++token;
-        char* savePtr = NULL;
-        char* c;
+        char *savePtr = NULL;
+        char *c;
 
         nextSpace(&token);
 
@@ -101,7 +101,7 @@ void scrotNoteNew(char* format)
             if (!note.font)
                 errx(EXIT_FAILURE, "Error --note option : Malformed syntax for -f");
 
-            char* number = strrchr(note.font, '/');
+            char *number = strrchr(note.font, '/');
 
             if (!number)
                 errx(EXIT_FAILURE, "Error --note option : Malformed syntax for -f, required number.");
@@ -139,7 +139,7 @@ void scrotNoteNew(char* format)
             while (c) {
                 token = c;
 
-                int const color = optionsParseRequireRange(
+                const int color = optionsParseRequireRange(
                         optionsParseRequiredNumber(c), 0 ,255);
 
                 switch (++numberColors) {
@@ -220,7 +220,7 @@ static void loadFont(void)
     }
 }
 
-static char* parseText(char** token, char* const end)
+static char *parseText(char **token, char *const end)
 {
     assert(NULL != *token);
     assert(NULL != end);
@@ -230,7 +230,7 @@ static char* parseText(char** token, char* const end)
 
     (*token)++;
 
-    char* begin = *token;
+    char *begin = *token;
 
     while ((*token != end) && **token != '\'')
         (*token)++;

--- a/src/note.h
+++ b/src/note.h
@@ -26,11 +26,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-/* This file is part of the scrot project. */
-
 #pragma once
 
-#include "options.h"
 #include <Imlib2.h>
 
 /*

--- a/src/note.h
+++ b/src/note.h
@@ -42,8 +42,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * */
 
 struct ScrotNote {
-    char* font; /* font name                   */
-    char* text; /* text of the note            */
+    char *font; /* font name                   */
+    char *text; /* text of the note            */
     int x; /* position screen (optional)  */
     int y; /* position screen (optional)  */
     double angle; /* angle text (optional)       */
@@ -58,6 +58,6 @@ struct ScrotNote {
 
 extern struct ScrotNote note;
 
-void scrotNoteNew(char*);
+void scrotNoteNew(char *);
 void scrotNoteFree(void);
 void scrotNoteDraw(Imlib_Image);

--- a/src/options.c
+++ b/src/options.c
@@ -92,7 +92,7 @@ int optionsParseRequiredNumber(const char *str)
 {
     assert(NULL != str); // fix yout caller function,
                          //  the user does not impose this behavior
-    char* end = NULL;
+    char *end = NULL;
     long ret = 0L;
     errno = 0;
 
@@ -125,7 +125,7 @@ int optionsParseRequireRange(int n, int lo, int hi)
     return (n < lo ? lo : n > hi ? hi : n);
 }
 
-static bool optionsParseIsString(const char *str)
+static bool optionsParseIsString(const char *const str)
 {
     return (str && (str[0] != '\0'));
 }

--- a/src/options.c
+++ b/src/options.c
@@ -39,9 +39,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "config.h"
+#include "note.h"
 #include "options.h"
 #include "scrot.h"
-#include <assert.h>
+#include "scrot_selection.h"
+#include "util.h"
 
 #define STR_LEN_MAX_FILENAME(msg, fileName) do {                \
     if (strlen((fileName)) > MAX_FILENAME) {                    \
@@ -70,6 +84,9 @@ struct ScrotOptions opt = {
     .lineMode = LINE_MODE_S_CLASSIC,
     .stackDirection = HORIZONTAL,
 };
+
+static void showUsage(void);
+static void showVersion(void);
 
 int optionsParseRequiredNumber(char const* str)
 {
@@ -301,7 +318,6 @@ static bool accessFileOk(const char* const pathName)
     return (0 == access(pathName, W_OK));
 }
 
-
 static char* getPathOfStdout(void)
 {
     char path[16] = {"/dev/stdout"};
@@ -468,6 +484,23 @@ void optionsParse(int argc, char** argv)
     optind = 1;
 }
 
+static void showUsage(void)
+{
+    fputs(/* Check that everything lines up after any changes. */
+        "usage:  " PACKAGE " [-bcfhikmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]"
+        "\n"
+        "              [-F FILE] [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \n"
+        "              [-t NUM | GEOM] [FILE]\n",
+        stdout);
+    exit(0);
+}
+
+static void showVersion(void)
+{
+    printf(PACKAGE " version " VERSION "\n");
+    exit(0);
+}
+
 char* optionsNameThumbnail(const char* name)
 {
     const char* const thumbSuffix = "-thumb";
@@ -582,21 +615,4 @@ int optionsCompareWindowClassName(const char* targetClassName)
     assert(targetClassName != NULL);
     assert(opt.windowClassName != NULL);
     return !!(!strncmp(targetClassName, opt.windowClassName, MAX_LEN_WINDOW_CLASS_NAME - 1));
-}
-
-void showVersion(void)
-{
-    printf(SCROT_PACKAGE " version " SCROT_VERSION "\n");
-    exit(0);
-}
-
-void showUsage(void)
-{
-    fputs(/* Check that everything lines up after any changes. */
-        "usage:  " SCROT_PACKAGE " [-bcfhikmopsuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]"
-        "\n"
-        "              [-F FILE] [-d SEC] [-e CMD] [-l STYLE] [-n OPTS] [-q NUM] [-S CMD] \n"
-        "              [-t NUM | GEOM] [FILE]\n",
-        stdout);
-    exit(0);
 }

--- a/src/options.c
+++ b/src/options.c
@@ -13,7 +13,7 @@ Copyright 2019-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2019      Jade Auer <jade@trashwitch.dev>
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2021      Wilson Smith <01wsmith+gh@gmail.com>
@@ -88,7 +88,7 @@ struct ScrotOptions opt = {
 static void showUsage(void);
 static void showVersion(void);
 
-int optionsParseRequiredNumber(char const* str)
+int optionsParseRequiredNumber(const char *str)
 {
     assert(NULL != str); // fix yout caller function,
                          //  the user does not impose this behavior
@@ -122,15 +122,15 @@ static int nonNegativeNumber(int number)
 
 int optionsParseRequireRange(int n, int lo, int hi)
 {
-   return (n < lo ? lo : n > hi ? hi : n);
+    return (n < lo ? lo : n > hi ? hi : n);
 }
 
-bool optionsParseIsString(char const* const str)
+static bool optionsParseIsString(const char *str)
 {
     return (str && (str[0] != '\0'));
 }
 
-static void optionsParseStack(char const* optarg)
+static void optionsParseStack(const char *optarg)
 {
     // the suboption it's optional
     if (!optarg) {
@@ -154,7 +154,7 @@ static void optionsParseStack(char const* optarg)
     }
 }
 
-static void optionsParseSelection(char const* optarg)
+static void optionsParseSelection(const char *optarg)
 {
     // the suboption it's optional
     if (!optarg) {
@@ -213,7 +213,7 @@ static void optionsParseSelection(char const* optarg)
     }
 }
 
-static void optionsParseLine(char* optarg)
+static void optionsParseLine(char *optarg)
 {
     enum {
         Style = 0,
@@ -304,7 +304,7 @@ static void optionsParseLine(char* optarg)
     } /* while */
 }
 
-static void optionsParseWindowClassName(const char* windowClassName)
+static void optionsParseWindowClassName(const char *windowClassName)
 {
     assert(windowClassName != NULL);
 
@@ -312,7 +312,7 @@ static void optionsParseWindowClassName(const char* windowClassName)
         opt.windowClassName = strndup(windowClassName, MAX_LEN_WINDOW_CLASS_NAME);
 }
 
-static bool accessFileOk(const char* const pathName)
+static bool accessFileOk(const char *const pathName)
 {
     errno = 0;
     return (0 == access(pathName, W_OK));
@@ -340,7 +340,7 @@ static char* getPathOfStdout(void)
     return strndup(path, len);
 }
 
-void optionsParse(int argc, char** argv)
+void optionsParse(int argc, char *argv[])
 {
     static char stropts[] = "a:ofipbcd:e:hmq:s::t:uvzn:l:D:k::C:S:F:";
 
@@ -501,7 +501,7 @@ static void showVersion(void)
     exit(0);
 }
 
-char* optionsNameThumbnail(const char* name)
+char *optionsNameThumbnail(const char *name)
 {
     const char* const thumbSuffix = "-thumb";
     const size_t thumbSuffixLength = 7;
@@ -525,7 +525,7 @@ char* optionsNameThumbnail(const char* name)
     return newName;
 }
 
-void optionsParseAutoselect(char* optarg)
+void optionsParseAutoselect(char *optarg)
 {
     char* token;
     const char tokenDelimiter[2] = ",";
@@ -548,14 +548,14 @@ void optionsParseAutoselect(char* optarg)
         errx(EXIT_FAILURE, "invalid format for option -- 'autoselect'");
 }
 
-void optionsParseDisplay(char* optarg)
+void optionsParseDisplay(char *optarg)
 {
     opt.display = strndup(optarg, MAX_DISPLAY_NAME);
     if (!opt.display)
         err(EXIT_FAILURE, "Unable to allocate display");
 }
 
-void optionsParseThumbnail(char* optarg)
+void optionsParseThumbnail(char *optarg)
 {
     char* token;
 
@@ -586,13 +586,13 @@ void optionsParseThumbnail(char* optarg)
     }
 }
 
-void optionsParseFileName(const char* optarg)
+void optionsParseFileName(const char *optarg)
 {
     checkMaxOutputFileName(optarg);
     opt.outputFile = estrdup(optarg);
 }
 
-void optionsParseNote(char* optarg)
+void optionsParseNote(char *optarg)
 {
     opt.note = estrdup(optarg);
 
@@ -610,7 +610,7 @@ Return:
     0 : It does not match
     1 : If it matches
 */
-int optionsCompareWindowClassName(const char* targetClassName)
+int optionsCompareWindowClassName(const char *targetClassName)
 {
     assert(targetClassName != NULL);
     assert(opt.windowClassName != NULL);

--- a/src/options.c
+++ b/src/options.c
@@ -137,7 +137,7 @@ static void optionsParseStack(const char *optarg)
         opt.stackDirection = HORIZONTAL;
         return;
     }
-    char const* value = strchr(optarg, '=');
+    const char *value = strchr(optarg, '=');
 
     if (value)
         ++value;
@@ -162,7 +162,7 @@ static void optionsParseSelection(const char *optarg)
         return;
     }
 
-    char const* value = strchr(optarg, '=');
+    const char *value = strchr(optarg, '=');
 
     if (value)
         ++value;
@@ -223,7 +223,7 @@ static void optionsParseLine(char *optarg)
         Mode
     };
 
-    char* const token[] = {
+    char *const token[] = {
         [Style] = "style",
         [Width] = "width",
         [Color] = "color",
@@ -232,8 +232,8 @@ static void optionsParseLine(char *optarg)
         NULL
     };
 
-    char* subopts = optarg;
-    char* value = NULL;
+    char *subopts = optarg;
+    char *value = NULL;
 
     while (*subopts != '\0') {
         switch (getsubopt(&subopts, token, &value)) {
@@ -318,10 +318,10 @@ static bool accessFileOk(const char *const pathName)
     return (0 == access(pathName, W_OK));
 }
 
-static char* getPathOfStdout(void)
+static char *getPathOfStdout(void)
 {
     char path[16] = {"/dev/stdout"};
-    size_t const len = sizeof(path);
+    const size_t len = sizeof(path);
 
     if (!accessFileOk(path)) {
 
@@ -468,7 +468,7 @@ void optionsParse(int argc, char *argv[])
         if (!opt.outputFile) {
             optionsParseFileName(argv[optind++]);
 
-            bool const redirectChar = ( opt.outputFile[0] == '-'
+            const bool redirectChar = ( opt.outputFile[0] == '-'
                                         && opt.outputFile[1] == '\0');
             if (redirectChar) {
                 free(opt.outputFile);
@@ -503,15 +503,15 @@ static void showVersion(void)
 
 char *optionsNameThumbnail(const char *name)
 {
-    const char* const thumbSuffix = "-thumb";
+    const char *const thumbSuffix = "-thumb";
     const size_t thumbSuffixLength = 7;
     const size_t newNameLength = strlen(name) + thumbSuffixLength;
-    char* newName = calloc(1, newNameLength);
+    char *newName = calloc(1, newNameLength);
 
     if (!newName)
         err(EXIT_FAILURE, "Unable to allocate thumbnail");
 
-    const char* const extension = strrchr(name, '.');
+    const char *const extension = strrchr(name, '.');
 
     if (extension) {
         /* We add one so length includes '\0'*/
@@ -527,7 +527,7 @@ char *optionsNameThumbnail(const char *name)
 
 void optionsParseAutoselect(char *optarg)
 {
-    char* token;
+    char *token;
     const char tokenDelimiter[2] = ",";
     int dimensions[4];
     int i = 0;
@@ -557,7 +557,7 @@ void optionsParseDisplay(char *optarg)
 
 void optionsParseThumbnail(char *optarg)
 {
-    char* token;
+    char *token;
 
     if (strchr(optarg, 'x')) { /* We want to specify the geometry */
         token = strtok(optarg, "x");

--- a/src/options.h
+++ b/src/options.h
@@ -11,7 +11,7 @@ Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2021      Wilson Smith <01wsmith+gh@gmail.com>
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -85,7 +85,7 @@ struct ScrotOptions {
 extern struct ScrotOptions opt;
 
 void optionsParse(int, char**);
-char* optionsNameThumbnail(const char*);
+char *optionsNameThumbnail(const char*);
 void optionsParseFileName(const char*);
 void optionsParseThumbnail(char*);
 void optionsParseAutoselect(char*);

--- a/src/options.h
+++ b/src/options.h
@@ -40,7 +40,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // General purpose enum
 enum Direction {
-    // see main.c:stalkImageConcat(...)
+    // see scrot.c:stalkImageConcat(...)
     HORIZONTAL,
     VERTICAL,
 };

--- a/src/options.h
+++ b/src/options.h
@@ -65,15 +65,15 @@ struct ScrotOptions {
     int lineOpacity;
     int stack;
     enum Direction stackDirection;
-    char* lineColor;
-    char* lineMode;
-    char* outputFile;
-    char* thumbFile;
-    char* exec;
-    char* display;
-    char* note;
-    char* windowClassName;
-    char* script;
+    char *lineColor;
+    char *lineMode;
+    char *outputFile;
+    char *thumbFile;
+    char *exec;
+    char *display;
+    char *note;
+    char *windowClassName;
+    char *script;
     int autoselect;
     int autoselectX;
     int autoselectY;
@@ -84,13 +84,13 @@ struct ScrotOptions {
 
 extern struct ScrotOptions opt;
 
-void optionsParse(int, char**);
-char *optionsNameThumbnail(const char*);
-void optionsParseFileName(const char*);
-void optionsParseThumbnail(char*);
-void optionsParseAutoselect(char*);
-void optionsParseDisplay(char*);
-void optionsParseNote(char*);
-int optionsParseRequiredNumber(char const *);
-int optionsCompareWindowClassName(const char*);
+void optionsParse(int, char **);
+char *optionsNameThumbnail(const char *);
+void optionsParseFileName(const char *);
+void optionsParseThumbnail(char *);
+void optionsParseAutoselect(char *);
+void optionsParseDisplay(char *);
+void optionsParseNote(char *);
+int optionsParseRequiredNumber(const char *);
+int optionsCompareWindowClassName(const char *);
 int optionsParseRequireRange(int, int, int);

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -748,7 +748,7 @@ static Imlib_Image scrotGrabStackWindows(void)
     XCompositeRedirectSubwindows(disp, root, CompositeRedirectAutomatic);
 
     for (i = 0; i < numberItemsReturn; i++) {
-        Window win = *((Window*)propReturn + i);
+        Window win = *((Window *)propReturn + i);
 
         if (!XGetWindowAttributes(disp, win, &attr))
             errx(EXIT_FAILURE, "option --stack: Failed XGetWindowAttributes");
@@ -822,7 +822,7 @@ static Imlib_Image stalkImageConcat(ScrotList *images, const enum Direction dir)
     int total = 0, max = 0;
     int x = 0, y = 0, w , h;
     Imlib_Image ret, im;
-    ScrotListNode* image = NULL;
+    ScrotListNode *image = NULL;
 
     const bool vertical = (dir == VERTICAL) ? true : false;
 

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -713,7 +713,7 @@ static Imlib_Image scrotGrabStackWindows(void)
     if (XGetSelectionOwner(disp, XInternAtom(disp, "_NET_WM_CM_S0", False))
         == None) {
         errx(EXIT_FAILURE, "option --stack: Composite Manager is not running,"
-            "required to use this option.");
+            " required to use this option.");
     }
 
     unsigned long numberItemsReturn;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -66,7 +66,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "util.h"
 
 static void uninitXAndImlib(void);
-static size_t scrotHaveFileExtension(char const *, char **);
+static size_t scrotHaveFileExtension(const char *, char **);
 static Imlib_Image scrotGrabFocused(void);
 static void applyFilterIfRequired(void);
 static Bool scrotXEventVisibility(Display *, XEvent *, XPointer);
@@ -80,20 +80,20 @@ static char *imPrintf(char *, struct tm *, char *, char *, Imlib_Image);
 static Window scrotGetClientWindow(Display *, Window);
 static Window scrotFindWindowByProperty(Display *, const Window,
                                               const Atom);
-static Imlib_Image  stalkImageConcat(ScrotList *, enum Direction const);
+static Imlib_Image stalkImageConcat(ScrotList *, const enum Direction);
 
 int main(int argc, char *argv[])
 {
     Imlib_Image image;
     Imlib_Image thumbnail;
     Imlib_Load_Error imErr;
-    char* filenameIM = NULL;
-    char* filenameThumb = NULL;
+    char *filenameIM = NULL;
+    char *filenameThumb = NULL;
 
-    char* haveExtension = NULL;
+    char *haveExtension = NULL;
 
     time_t t;
-    struct tm* tm;
+    struct tm *tm;
 
     optionsParse(argc, argv);
 
@@ -214,7 +214,7 @@ static void uninitXAndImlib(void)
     }
 }
 
-static size_t scrotHaveFileExtension(const char *filename, char** ext)
+static size_t scrotHaveFileExtension(const char *filename, char **ext)
 {
     *ext = strrchr(filename, '.');
 
@@ -358,7 +358,7 @@ int scrotGetGeometry(Window target, int *rx, int *ry, int *rw, int *rh)
     return 1;
 }
 
-Window scrotGetWindow(Display* display, Window window, int x, int y)
+Window scrotGetWindow(Display *display, Window window, int x, int y)
 {
     Window source, target;
 
@@ -389,7 +389,7 @@ Window scrotGetWindow(Display* display, Window window, int x, int y)
 void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     const int yOffset)
 {
-    XFixesCursorImage* xcim = XFixesGetCursorImage(disp);
+    XFixesCursorImage *xcim = XFixesGetCursorImage(disp);
 
     if (!xcim) {
         warnx("Failed to get mouse cursor image.");
@@ -400,10 +400,10 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     const unsigned short height = xcim->height;
     const int x = (xcim->x - xcim->xhot) - xOffset;
     const int y = (xcim->y - xcim->yhot) - yOffset;
-    DATA32* pixels = NULL;
+    DATA32 *pixels = NULL;
 
 #ifdef __i386__
-    pixels = (DATA32*)xcim->pixels;
+    pixels = (DATA32 *)xcim->pixels;
 #else
     DATA32 data[width * height * 4];
 
@@ -449,12 +449,12 @@ static void scrotCheckIfOverwriteFile(char **filename)
 
     const size_t maxCounter = 999;
     size_t counter = 0;
-    char* ext = NULL;
+    char *ext = NULL;
     size_t extLength = 0;
     const size_t slen = strlen(*filename);
     size_t nalloc = slen + 4 + 1; // _000 + NUL byte
     char fmt[5];
-    char* newName = NULL;
+    char *newName = NULL;
 
     extLength = scrotHaveFileExtension(*filename, &ext);
 
@@ -465,7 +465,7 @@ static void scrotCheckIfOverwriteFile(char **filename)
     memcpy(newName, *filename, slen);
 
     do {
-        char* ptr = newName + slen;
+        char *ptr = newName + slen;
 
         snprintf(fmt, sizeof(fmt), "_%03zu", counter++);
 
@@ -531,7 +531,7 @@ static Imlib_Image scrotGrabShot(void)
 static void scrotExecApp(Imlib_Image image, struct tm *tm, char *filenameIM,
     char *filenameThumb)
 {
-    char* execStr;
+    char *execStr;
     int ret;
 
     execStr = imPrintf(opt.exec, tm, filenameIM, filenameThumb, image);
@@ -551,18 +551,18 @@ static void scrotExecApp(Imlib_Image image, struct tm *tm, char *filenameIM,
 static Bool scrotXEventVisibility(Display *dpy, XEvent *ev, XPointer arg)
 {
     (void)dpy; // unused
-    Window* win = (Window*)arg;
+    Window *win = (Window *)arg;
     return (ev->xvisibility.window == *win);
 }
 
 static char *imPrintf(char *str, struct tm *tm, char *filenameIM,
     char *filenameThumb, Imlib_Image im)
 {
-    char* c;
+    char *c;
     char buf[20];
     char ret[4096];
     char strf[4096];
-    char* tmp;
+    char *tmp;
     struct stat st;
 
     ret[0] = '\0';
@@ -660,7 +660,7 @@ static Window scrotGetClientWindow(Display *display, Window target)
     Atom state;
     Atom type = None;
     int format, status;
-    unsigned char* data;
+    unsigned char *data;
     unsigned long after, items;
     Window client;
 
@@ -683,7 +683,7 @@ static Window scrotFindWindowByProperty(Display *display, const Window window,
 {
     Atom type = None;
     int format, status;
-    unsigned char* data;
+    unsigned char *data;
     unsigned int i, numberChildren;
     unsigned long after, numberItems;
     Window child = None, *children, parent, rootReturn;
@@ -718,14 +718,14 @@ static Imlib_Image scrotGrabStackWindows(void)
 
     unsigned long numberItemsReturn;
     unsigned long bytesAfterReturn;
-    unsigned char* propReturn;
+    unsigned char *propReturn;
     long offset = 0L;
     long length = ~0L;
     Bool delete = False;
     int actualFormatReturn;
     Atom actualTypeReturn;
     Imlib_Image im = NULL;
-    XImage* ximage = NULL;
+    XImage *ximage = NULL;
     XWindowAttributes attr;
     unsigned long i = 0;
 
@@ -786,8 +786,8 @@ static Imlib_Image scrotGrabShotMulti(void)
         return scrotGrabShot();
 
     int i;
-    char* dispStr;
-    char* subDisp;
+    char *dispStr;
+    char *subDisp;
     char newDisp[255];
     Imlib_Image ret = NULL;
 
@@ -814,7 +814,7 @@ static Imlib_Image scrotGrabShotMulti(void)
     return stalkImageConcat(&images, HORIZONTAL);
 }
 
-static Imlib_Image stalkImageConcat(ScrotList *images, enum Direction const dir)
+static Imlib_Image stalkImageConcat(ScrotList *images, const enum Direction dir)
 {
     if (isEmptyScrotList(images))
         return NULL;
@@ -824,7 +824,7 @@ static Imlib_Image stalkImageConcat(ScrotList *images, enum Direction const dir)
     Imlib_Image ret, im;
     ScrotListNode* image = NULL;
 
-    bool const vertical = (dir == VERTICAL) ? true : false;
+    const bool vertical = (dir == VERTICAL) ? true : false;
 
     forEachScrotList(images, image) {
         im = (Imlib_Image) image->data;

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -1,15 +1,6 @@
 /* scrot.h
 
-Copyright 1999-2000 Tom Gilbert <tom@linuxbrit.co.uk,
-                                  gilbertt@linuxbrit.co.uk,
-                                  scrot_sucks@linuxbrit.co.uk>
-Copyright 2009      James Cameron <quozl@us.netrek.org>
-Copyright 2019-2021 Daniel T. Borelli <danieltborelli@gmail.com>
-Copyright 2020      Jeroen Roovers <jer@gentoo.org>
-Copyright 2020      Hinigatsu <hinigatsu@protonmail.com>
-Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
 Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
-Copyright 2021      Peter Wu <peterwu@hotmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -32,75 +23,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
+/* Part of the code comes from the scrot.c file and maintains its authorship. */
+
 #pragma once
 
-#include <X11/Xatom.h>
 #include <X11/Xlib.h>
-#include <X11/Xos.h>
-#include <X11/Xutil.h>
-#include <X11/extensions/Xcomposite.h>
-
 #include <Imlib2.h>
-#include <ctype.h>
-#include <dirent.h>
-#include <err.h>
-#include <errno.h>
-#include <getopt.h>
-#include <limits.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <time.h>
-#include <unistd.h>
 
-#include "options.h"
-#include "note.h"
-#include "scrot_config.h"
-#include "scrot_selection.h"
-#include "slist.h"
-#include "util.h"
-
-typedef void (*signalHandler)(int);
-
-void showUsage(void);
-void showVersion(void);
-void initXAndImlib(char*, int);
-Imlib_Image scrotGrabShot(void);
-void scrotExecApp(Imlib_Image, struct tm*, char*, char*);
-void scrotDoDelay(void);
-Imlib_Image scrotGrabFocused(void);
-Imlib_Image scrotGrabAutoselect(void);
-void scrotSelArea(int*, int*, int*, int*);
-void scrotNiceClip(int*, int*, int*, int*);
-int scrotGetGeometry(Window, int*, int*, int*, int*);
-int scrotMatchWindowClassName(Window);
 Window scrotGetWindow(Display*, Window, int, int);
-Window scrotGetClientWindow(Display*, Window);
-Window scrotFindWindowByProperty(Display*, const Window, const Atom);
-char* imPrintf(char*, struct tm*, char*, char*, Imlib_Image);
-Imlib_Image scrotGrabShotMulti(void);
-Imlib_Image scrotGrabStackWindows(void);
-Imlib_Image stalkImageConcat(ScrotList*, enum Direction const);
-
+int scrotGetGeometry(Window, int*, int*, int*, int*);
+void scrotNiceClip(int*, int*, int*, int*);
+void scrotDoDelay(void);
 void scrotGrabMousePointer(const Imlib_Image, const int, const int);
-
-void scrotCheckIfOverwriteFile(char**);
-size_t scrotHaveFileExtension(char const*, char**);
-
-/* Imlib stuff */
-extern Display* disp;
-extern Visual* vis;
-extern Colormap cm;
-extern int depth;
-
-/* Thumbnail sizes */
-extern Window root;
-extern Screen* scr;

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -30,8 +30,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xlib.h>
 #include <Imlib2.h>
 
-Window scrotGetWindow(Display*, Window, int, int);
-int scrotGetGeometry(Window, int*, int*, int*, int*);
-void scrotNiceClip(int*, int*, int*, int*);
+Window scrotGetWindow(Display *, Window, int, int);
+int scrotGetGeometry(Window, int *, int *, int *, int *);
+void scrotNiceClip(int *, int *, int *, int *);
 void scrotDoDelay(void);
 void scrotGrabMousePointer(const Imlib_Image, const int, const int);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -55,26 +55,26 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 struct Selection **selectionGet(void)
 {
-    static struct Selection* sel = NULL;
+    static struct Selection *sel = NULL;
     return &sel;
 }
 
 static void selectionAllocate(void)
 {
-    struct Selection** sel = selectionGet();
+    struct Selection **sel = selectionGet();
     *sel = calloc(1, sizeof(**sel));
 }
 
 static void selectionDeallocate(void)
 {
-    struct Selection** sel = selectionGet();
+    struct Selection **sel = selectionGet();
     free(*sel);
     *sel = NULL;
 }
 
 static void createCursors(void)
 {
-    struct Selection* const sel = *selectionGet();
+    struct Selection *const sel = *selectionGet();
 
     assert(sel != NULL);
 
@@ -94,7 +94,7 @@ static void createCursors(void)
 
 static void freeCursors(void)
 {
-    struct Selection* const sel = *selectionGet();
+    struct Selection *const sel = *selectionGet();
 
     assert(sel != NULL);
 
@@ -107,7 +107,7 @@ static void freeCursors(void)
 
 void selectionCalculateRect(int x0, int y0, int x1, int y1)
 {
-    struct SelectionRect* const rect = scrotSelectionGetRect();
+    struct SelectionRect *const rect = scrotSelectionGetRect();
 
     rect->x = x0;
     rect->y = y0;
@@ -135,7 +135,7 @@ void scrotSelectionCreate(void)
 {
     selectionAllocate();
 
-    struct Selection* const sel = *selectionGet();
+    struct Selection *const sel = *selectionGet();
 
     assert(sel != NULL);
 
@@ -170,7 +170,7 @@ void scrotSelectionCreate(void)
 
 void scrotSelectionDestroy(void)
 {
-    struct Selection* const sel = *selectionGet();
+    struct Selection *const sel = *selectionGet();
     XUngrabPointer(disp, CurrentTime);
     freeCursors();
     XSync(disp, True);
@@ -180,14 +180,14 @@ void scrotSelectionDestroy(void)
 
 void scrotSelectionDraw(void)
 {
-    struct Selection const* const sel = *selectionGet();
+    const struct Selection *const sel = *selectionGet();
     sel->draw();
 }
 
 void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)
 {
-    struct Selection const* const sel = *selectionGet();
-    unsigned int const EVENT_MASK = ButtonMotionMask | ButtonReleaseMask;
+    const struct Selection *const sel = *selectionGet();
+    const unsigned int EVENT_MASK = ButtonMotionMask | ButtonReleaseMask;
     Cursor cursor = None;
 
     if (x1 > x0 && y1 > y0)
@@ -220,7 +220,7 @@ void scrotSelectionGetLineColor(XColor *color)
 {
     scrotSelectionSetDefaultColorLine();
 
-    Status const ret = scrotSelectionCreateNamedColor(opt.lineColor, color);
+    const Status ret = scrotSelectionCreateNamedColor(opt.lineColor, color);
 
     if (!ret) {
         scrotSelectionDestroy();
@@ -286,7 +286,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
                 break;
             case KeyPress:
             {
-                KeySym* keysym = NULL;
+                KeySym *keysym = NULL;
                 int keycode; /*dummy*/
 
                 keysym = XGetKeyboardMapping(disp, ev.xkey.keycode, 1, &keycode);
@@ -353,7 +353,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
 
     XUngrabKeyboard(disp, CurrentTime);
 
-    bool const isAreaSelect = (scrotSelectionGetRect()->w > 5);
+    const bool isAreaSelect = (scrotSelectionGetRect()->w > 5);
 
     scrotSelectionDestroy();
 
@@ -402,7 +402,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
     return true;
 }
 
-static void changeImageOpacity(Imlib_Image image, int const opacity)
+static void changeImageOpacity(Imlib_Image image, const int opacity)
 {
 #define PIXEL_ARGB(a, r, g, b)  ((a) << 24) | ((r) << 16) | ((g) << 8) | (b)
 #define PIXEL_A(argb)  (((argb) >> 24) & 0xff)
@@ -411,24 +411,24 @@ static void changeImageOpacity(Imlib_Image image, int const opacity)
 #define PIXEL_B(argb)  (((argb)      ) & 0xff)
 
     imlib_context_set_image(image);
-    int const w = imlib_image_get_width();
-    int const h = imlib_image_get_height();
+    const int w = imlib_image_get_width();
+    const int h = imlib_image_get_height();
 
-    DATA32* data = imlib_image_get_data();
-    DATA32* end = data + (h * w);
+    DATA32 *data = imlib_image_get_data();
+    DATA32 *end = data + (h * w);
 
-    for (DATA32* pixel = data; pixel != end; ++pixel) {
-        DATA8 const a = PIXEL_A(*pixel) * opacity / 255;
-        DATA8 const r = PIXEL_R(*pixel);
-        DATA8 const g = PIXEL_G(*pixel);
-        DATA8 const b = PIXEL_B(*pixel);
+    for (DATA32 *pixel = data; pixel != end; ++pixel) {
+        const DATA8 a = PIXEL_A(*pixel) * opacity / 255;
+        const DATA8 r = PIXEL_R(*pixel);
+        const DATA8 g = PIXEL_G(*pixel);
+        const DATA8 b = PIXEL_B(*pixel);
        *pixel = (DATA32)PIXEL_ARGB(a, r, g, b);
     }
 
     imlib_image_put_back_data(data);
 }
 
-static Imlib_Image loadImage(const char *const fileName, int const opacity)
+static Imlib_Image loadImage(const char *const fileName, const int opacity)
 {
     Imlib_Image image = imlib_load_image(fileName);
 
@@ -459,7 +459,7 @@ Imlib_Image scrotSelectionSelectMode(void)
 {
     struct SelectionRect rect0, rect1;
 
-    unsigned int const oldMode = opt.selection.mode;
+    const unsigned int oldMode = opt.selection.mode;
 
     opt.selection.mode = SELECTION_MODE_CAPTURE;
 
@@ -486,9 +486,9 @@ Imlib_Image scrotSelectionSelectMode(void)
     XColor color;
     scrotSelectionGetLineColor(&color);
 
-    int const x = rect1.x - rect0.x;
-    int const y = rect1.y - rect0.y;
-    int const opacity = optionsParseRequireRange(opt.lineOpacity,
+    const int x = rect1.x - rect0.x;
+    const int y = rect1.y - rect0.y;
+    const int opacity = optionsParseRequireRange(opt.lineOpacity,
             SELECTION_OPACITY_MIN, SELECTION_OPACITY_MAX);
 
     imlib_context_set_image(capture);
@@ -506,7 +506,7 @@ Imlib_Image scrotSelectionSelectMode(void)
         break;
     case SELECTION_MODE_HIDE:
     {
-        char* const fileName = opt.selection.paramStr;
+        char *const fileName = opt.selection.paramStr;
 
         if (fileName) {
             if (opacity > 0) {
@@ -528,7 +528,7 @@ Imlib_Image scrotSelectionSelectMode(void)
     }
     case SELECTION_MODE_BLUR:
     {
-        int const amountBlur = opt.selection.paramNum;
+        const int amountBlur = opt.selection.paramNum;
         Imlib_Image blur = imlib_clone_image();
         imlib_context_set_image(blur);
         imlib_image_blur(amountBlur);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -4,6 +4,7 @@ Copyright 2020-2021  Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021       Martin C <martincation@protonmail.com>
 Copyright 2021       Peter Wu <peterwu@hotmail.com>
 Copyright 2021       Wilson Smith <01wsmith+gh@gmail.com>
+Copyright 2021       Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -28,9 +29,25 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /*
     This file is part of the scrot project.
-    Part of the code comes from the main.c file and maintains its authorship.
+    Part of the code comes from the scrot.c file and maintains its authorship.
 */
 
+#include <sys/select.h>
+
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <Imlib2.h>
+#include <X11/Xlib.h>
+#include <X11/cursorfont.h>
+#include <X11/keysym.h>
+
+#include "imlib.h"
+#include "options.h"
 #include "scrot.h"
 #include "selection_classic.h"
 #include "selection_edge.h"

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -4,7 +4,7 @@ Copyright 2020-2021  Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021       Martin C <martincation@protonmail.com>
 Copyright 2021       Peter Wu <peterwu@hotmail.com>
 Copyright 2021       Wilson Smith <01wsmith+gh@gmail.com>
-Copyright 2021       Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022  Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -49,10 +49,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "imlib.h"
 #include "options.h"
 #include "scrot.h"
+#include "scrot_selection.h"
 #include "selection_classic.h"
 #include "selection_edge.h"
 
-struct Selection** selectionGet(void)
+struct Selection **selectionGet(void)
 {
     static struct Selection* sel = NULL;
     return &sel;
@@ -201,12 +202,12 @@ void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)
     sel->motionDraw(x0, y0, x1, y1);
 }
 
-struct SelectionRect* scrotSelectionGetRect(void)
+struct SelectionRect *scrotSelectionGetRect(void)
 {
     return &(*selectionGet())->rect;
 }
 
-Status scrotSelectionCreateNamedColor(char const* nameColor, XColor* color)
+Status scrotSelectionCreateNamedColor(const char *nameColor, XColor *color)
 {
     assert(nameColor != NULL);
     assert(color != NULL);
@@ -215,7 +216,7 @@ Status scrotSelectionCreateNamedColor(char const* nameColor, XColor* color)
         nameColor, color, &(XColor){0});
 }
 
-void scrotSelectionGetLineColor(XColor* color)
+void scrotSelectionGetLineColor(XColor *color)
 {
     scrotSelectionSetDefaultColorLine();
 
@@ -233,7 +234,7 @@ void scrotSelectionSetDefaultColorLine(void)
         opt.lineColor = "gray";
 }
 
-bool scrotSelectionGetUserSel(struct SelectionRect* selectionRect)
+bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
 {
     static int xfd = 0;
     static int fdSize = 0;
@@ -427,7 +428,7 @@ static void changeImageOpacity(Imlib_Image image, int const opacity)
     imlib_image_put_back_data(data);
 }
 
-static Imlib_Image loadImage(char const* const fileName, int const opacity)
+static Imlib_Image loadImage(const char *const fileName, int const opacity)
 {
     Imlib_Image image = imlib_load_image(fileName);
 

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -3,6 +3,7 @@
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Martin C <martincation@protonmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -27,19 +28,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /*
     This file is part of the scrot project.
-    Part of the code comes from the main.c file and maintains its authorship.
+    Part of the code comes from the scrot.c file and maintains its authorship.
 */
 
 #pragma once
 
-#include <X11/Xresource.h>
-#include <X11/extensions/Xfixes.h>
-#include <X11/extensions/shape.h>
-#include <X11/keysym.h>
-#include <X11/cursorfont.h>
-#include <Imlib2.h>
 #include <stdbool.h>
-#include <assert.h>
+
+#include <Imlib2.h>
+#include <X11/Xlib.h>
 
 /* S: string, L: len */
 #define LINE_MODE_S_CLASSIC "classic"

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -104,7 +104,7 @@ void scrotSelectionCreate(void);
 void scrotSelectionDestroy(void);
 void scrotSelectionDraw(void);
 void scrotSelectionMotionDraw(int, int, int, int);
-struct SelectionRect* scrotSelectionGetRect(void);
+struct SelectionRect *scrotSelectionGetRect(void);
 void scrotSelectionGetLineColor(XColor *);
 Status scrotSelectionCreateNamedColor(const char *, XColor *);
 void scrotSelectionSetDefaultColorLine(void);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -3,7 +3,7 @@
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Martin C <martincation@protonmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -79,7 +79,7 @@ struct SelectionRect {
 typedef struct SelectionMode {
     unsigned int mode;
     int paramNum;
-    char* paramStr;
+    char *paramStr;
 } SelectionMode;
 
 struct SelectionClassic;
@@ -89,8 +89,8 @@ struct Selection {
     Cursor curCross, curAngleNW, curAngleNE, curAngleSW, curAngleSE;
 
     struct SelectionRect rect;
-    struct SelectionClassic* classic;
-    struct SelectionEdge* edge;
+    struct SelectionClassic *classic;
+    struct SelectionEdge *edge;
 
     void (*create)(void);
     void (*destroy)(void);
@@ -98,13 +98,15 @@ struct Selection {
     void (*motionDraw)(int, int, int, int);
 };
 
+struct Selection **selectionGet(void);
+void selectionCalculateRect(int, int, int, int);
 void scrotSelectionCreate(void);
 void scrotSelectionDestroy(void);
 void scrotSelectionDraw(void);
 void scrotSelectionMotionDraw(int, int, int, int);
 struct SelectionRect* scrotSelectionGetRect(void);
-void scrotSelectionGetLineColor(XColor*);
-Status scrotSelectionCreateNamedColor(char const*, XColor*);
+void scrotSelectionGetLineColor(XColor *);
+Status scrotSelectionCreateNamedColor(const char *, XColor *);
 void scrotSelectionSetDefaultColorLine(void);
-bool scrotSelectionGetUserSel(struct SelectionRect*);
+bool scrotSelectionGetUserSel(struct SelectionRect *);
 Imlib_Image scrotSelectionSelectMode(void);

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -49,14 +49,14 @@ struct SelectionClassic {
 
 void selectionClassicCreate(void)
 {
-    struct Selection* const sel = *selectionGet();
+    struct Selection *const sel = *selectionGet();
 
     sel->classic = calloc(1, sizeof(*sel->classic));
 
-    struct SelectionClassic* pc = sel->classic;
+    struct SelectionClassic *pc = sel->classic;
 
-    unsigned long const whiteColor = XWhitePixel(disp, 0);
-    unsigned long const blackColor = XBlackPixel(disp, 0);
+    const unsigned long whiteColor = XWhitePixel(disp, 0);
+    const unsigned long blackColor = XBlackPixel(disp, 0);
 
     pc->gcValues.function = GXxor;
     pc->gcValues.foreground = whiteColor;
@@ -85,8 +85,8 @@ void selectionClassicCreate(void)
 
 void selectionClassicDraw(void)
 {
-    struct Selection const *const sel = *selectionGet();
-    struct SelectionClassic const *const pc = sel->classic;
+    const struct Selection *const sel = *selectionGet();
+    const struct SelectionClassic *const pc = sel->classic;
     XDrawRectangle(disp, root, pc->gc, sel->rect.x, sel->rect.y, sel->rect.w,
         sel->rect.h);
     XFlush(disp);
@@ -94,7 +94,7 @@ void selectionClassicDraw(void)
 
 void selectionClassicMotionDraw(int x0, int y0, int x1, int y1)
 {
-    struct Selection const *const sel = *selectionGet();
+    const struct Selection *const sel = *selectionGet();
 
     if (sel->rect.w)
         selectionClassicDraw();
@@ -104,7 +104,7 @@ void selectionClassicMotionDraw(int x0, int y0, int x1, int y1)
 
 void selectionClassicDestroy(void)
 {
-    struct Selection const *const sel = *selectionGet();
+    const struct Selection *const sel = *selectionGet();
     struct SelectionClassic *pc = sel->classic;
 
     if (opt.freeze)

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -2,6 +2,7 @@
 
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -26,8 +27,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /*
     This file is part of the scrot project.
-    Part of the code comes from the main.c file and maintains its authorship.
+    Part of the code comes from the scrot.c file and maintains its authorship.
 */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <X11/Xlib.h>
+
+#include "imlib.h"
+#include "options.h"
+#include "scrot.h"
+#include "scrot_selection.h"
 #include "selection_classic.h"
 
 extern void selectionCalculateRect(int, int, int, int);

--- a/src/selection_classic.h
+++ b/src/selection_classic.h
@@ -2,7 +2,7 @@
 
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -33,6 +33,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 void selectionClassicCreate(void);
-void selectionClassicDestroy(void);
 void selectionClassicDraw(void);
 void selectionClassicMotionDraw(int, int, int, int);
+void selectionClassicDestroy(void);

--- a/src/selection_classic.h
+++ b/src/selection_classic.h
@@ -2,6 +2,7 @@
 
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -26,12 +27,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /*
     This file is part of the scrot project.
-    Part of the code comes from the main.c file and maintains its authorship.
+    Part of the code comes from the scrot.c file and maintains its authorship.
 */
 
 #pragma once
-
-#include "scrot.h"
 
 void selectionClassicCreate(void);
 void selectionClassicDestroy(void);

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -2,6 +2,7 @@
 
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -26,9 +27,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 /*
     This file is part of the scrot project.
-    Part of the code comes from the main.c file and maintains its authorship.
+    Part of the code comes from the scrot.c file and maintains its authorship.
 */
-#include "scrot.h"
+
+#include <stdlib.h>
+#include <time.h>
+
+#include <X11/Xatom.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/shape.h>
+
+#include "imlib.h"
+#include "options.h"
+#include "scrot_selection.h"
+#include "selection_edge.h"
 
 extern void selectionCalculateRect(int, int, int, int);
 extern struct Selection** selectionGet(void);

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -74,7 +74,7 @@ void selectionEdgeCreate(void)
         HeightOfScreen(scr), 0, CopyFromParent, InputOutput, CopyFromParent,
         CWOverrideRedirect | CWBackPixel, &attr);
 
-    int const lineOpacity = optionsParseRequireRange(opt.lineOpacity,
+    const int lineOpacity = optionsParseRequireRange(opt.lineOpacity,
             SELECTION_EDGE_OPACITY_MIN, SELECTION_OPACITY_MAX);
 
     unsigned long opacity = lineOpacity * ((unsigned)-1 / 100);

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -2,7 +2,7 @@
 
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
-Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -43,25 +43,107 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot_selection.h"
 #include "selection_edge.h"
 
-extern void selectionCalculateRect(int, int, int, int);
-extern struct Selection** selectionGet(void);
-
 struct SelectionEdge {
     Window wndDraw;
-    XClassHint* classHint;
+    XClassHint *classHint;
 };
 
-static Bool xeventUnmap(Display* dpy, XEvent* ev, XPointer arg)
+static void waitUnmapWindowNotify(void);
+static Bool xeventUnmap(Display *, XEvent *, XPointer);
+
+void selectionEdgeCreate(void)
 {
-    (void)dpy; // unused
-    Window* win = (Window*)arg;
-    return (ev->xunmap.window == *win);
+    struct Selection *const sel = *selectionGet();
+
+    sel->edge = calloc(1, sizeof(*sel->edge));
+
+    struct SelectionEdge *const pe = sel->edge;
+
+    XColor color;
+    scrotSelectionGetLineColor(&color);
+
+    XSetWindowAttributes attr;
+    attr.background_pixel = color.pixel;
+    attr.override_redirect = True;
+
+    pe->classHint = XAllocClassHint();
+    pe->classHint->res_name = "scrot";
+    pe->classHint->res_class = "scrot";
+
+    pe->wndDraw = XCreateWindow(disp, root, 0, 0, WidthOfScreen(scr),
+        HeightOfScreen(scr), 0, CopyFromParent, InputOutput, CopyFromParent,
+        CWOverrideRedirect | CWBackPixel, &attr);
+
+    int const lineOpacity = optionsParseRequireRange(opt.lineOpacity,
+            SELECTION_EDGE_OPACITY_MIN, SELECTION_OPACITY_MAX);
+
+    unsigned long opacity = lineOpacity * ((unsigned)-1 / 100);
+
+    XChangeProperty(disp, pe->wndDraw,
+        XInternAtom(disp, "_NET_WM_WINDOW_OPACITY", False), XA_CARDINAL, 32,
+        PropModeReplace, (unsigned char *) &opacity, 1L);
+
+    XChangeProperty(disp, pe->wndDraw,
+        XInternAtom(disp, "_NET_WM_WINDOW_TYPE", False), XA_ATOM, 32,
+        PropModeReplace,
+        (unsigned char *) &(Atom) { XInternAtom(disp, "_NET_WM_WINDOW_TYPE_DOCK", False) },
+        1L);
+
+    XSetClassHint(disp, pe->wndDraw, pe->classHint);
+}
+
+void selectionEdgeDraw(void)
+{
+    const struct Selection *const sel = *selectionGet();
+    const struct SelectionEdge *const pe = sel->edge;
+
+    XRectangle rects[4] = {
+        { sel->rect.x, sel->rect.y, opt.lineWidth, sel->rect.h }, // left
+        { sel->rect.x, sel->rect.y, sel->rect.w, opt.lineWidth }, // top
+        // right
+        { sel->rect.x + sel->rect.w, sel->rect.y, opt.lineWidth, sel->rect.h },
+        // bottom
+        { sel->rect.x, sel->rect.y + sel->rect.h, sel->rect.w + opt.lineWidth,
+            opt.lineWidth }
+    };
+
+    XShapeCombineRectangles(disp, pe->wndDraw, ShapeBounding, 0, 0, rects, 4,
+        ShapeSet, 0);
+    XMapWindow(disp, pe->wndDraw);
+}
+
+void selectionEdgeMotionDraw(int x0, int y0, int x1, int y1)
+{
+    struct Selection *const sel = *selectionGet();
+
+    selectionCalculateRect(x0, y0, x1, y1);
+
+    sel->rect.x -= opt.lineWidth;
+    sel->rect.y -= opt.lineWidth;
+    sel->rect.w += opt.lineWidth;
+    sel->rect.h += opt.lineWidth;
+
+    selectionEdgeDraw();
+}
+
+void selectionEdgeDestroy(void)
+{
+    const struct Selection *const sel = *selectionGet();
+    struct SelectionEdge *pe = sel->edge;
+
+    if (pe->wndDraw != 0) {
+        waitUnmapWindowNotify();
+        XFree(pe->classHint);
+        XDestroyWindow(disp, pe->wndDraw);
+    }
+
+    free(pe);
 }
 
 static void waitUnmapWindowNotify(void)
 {
-    struct Selection const* const sel = *selectionGet();
-    struct SelectionEdge const* const pe = sel->edge;
+    const struct Selection *const sel = *selectionGet();
+    const struct SelectionEdge *const pe = sel->edge;
     XEvent ev;
 
     XSelectInput(disp, pe->wndDraw, StructureNotifyMask);
@@ -77,85 +159,10 @@ static void waitUnmapWindowNotify(void)
     }
 }
 
-void selectionEdgeCreate(void)
+
+static Bool xeventUnmap(Display *dpy, XEvent *ev, XPointer arg)
 {
-    struct Selection* const sel = *selectionGet();
-
-    sel->edge = calloc(1, sizeof(*sel->edge));
-
-    struct SelectionEdge* const pe = sel->edge;
-
-    XColor color;
-    scrotSelectionGetLineColor(&color);
-
-    XSetWindowAttributes attr;
-    attr.background_pixel = color.pixel;
-    attr.override_redirect = True;
-
-    pe->classHint = XAllocClassHint();
-    pe->classHint->res_name = "scrot";
-    pe->classHint->res_class = "scrot";
-
-    pe->wndDraw = XCreateWindow(disp, root, 0, 0, WidthOfScreen(scr), HeightOfScreen(scr), 0,
-        CopyFromParent, InputOutput, CopyFromParent, CWOverrideRedirect | CWBackPixel, &attr);
-
-    int const lineOpacity = optionsParseRequireRange(opt.lineOpacity,
-            SELECTION_EDGE_OPACITY_MIN, SELECTION_OPACITY_MAX);
-
-    unsigned long opacity = lineOpacity * ((unsigned)-1 / 100);
-
-    XChangeProperty(disp, pe->wndDraw, XInternAtom(disp, "_NET_WM_WINDOW_OPACITY", False),
-        XA_CARDINAL, 32, PropModeReplace,
-        (unsigned char*) &opacity, 1L);
-
-    XChangeProperty(disp, pe->wndDraw, XInternAtom(disp, "_NET_WM_WINDOW_TYPE", False),
-        XA_ATOM, 32, PropModeReplace,
-        (unsigned char*) &(Atom) { XInternAtom(disp, "_NET_WM_WINDOW_TYPE_DOCK", False) },
-        1L);
-
-    XSetClassHint(disp, pe->wndDraw, pe->classHint);
-}
-
-void selectionEdgeDestroy(void)
-{
-    struct Selection const* const sel = *selectionGet();
-    struct SelectionEdge* pe = sel->edge;
-
-    if (pe->wndDraw != 0) {
-        waitUnmapWindowNotify();
-        XFree(pe->classHint);
-        XDestroyWindow(disp, pe->wndDraw);
-    }
-
-    free(pe);
-}
-
-void selectionEdgeDraw(void)
-{
-    struct Selection const* const sel = *selectionGet();
-    struct SelectionEdge const* const pe = sel->edge;
-
-    XRectangle rects[4] = {
-        { sel->rect.x, sel->rect.y, opt.lineWidth, sel->rect.h }, // left
-        { sel->rect.x, sel->rect.y, sel->rect.w, opt.lineWidth }, // top
-        { sel->rect.x + sel->rect.w, sel->rect.y, opt.lineWidth, sel->rect.h }, // right
-        { sel->rect.x, sel->rect.y + sel->rect.h, sel->rect.w + opt.lineWidth, opt.lineWidth } // bottom
-    };
-
-    XShapeCombineRectangles(disp, pe->wndDraw, ShapeBounding, 0, 0, rects, 4, ShapeSet, 0);
-    XMapWindow(disp, pe->wndDraw);
-}
-
-void selectionEdgeMotionDraw(int x0, int y0, int x1, int y1)
-{
-    struct Selection* const sel = *selectionGet();
-
-    selectionCalculateRect(x0, y0, x1, y1);
-
-    sel->rect.x -= opt.lineWidth;
-    sel->rect.y -= opt.lineWidth;
-    sel->rect.w += opt.lineWidth;
-    sel->rect.h += opt.lineWidth;
-
-    selectionEdgeDraw();
+    (void)dpy; // unused
+    Window *win = arg;
+    return (ev->xunmap.window == *win);
 }

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -163,6 +163,6 @@ static void waitUnmapWindowNotify(void)
 static Bool xeventUnmap(Display *dpy, XEvent *ev, XPointer arg)
 {
     (void)dpy; // unused
-    Window *win = arg;
+    Window *win = (Window *)arg;
     return (ev->xunmap.window == *win);
 }

--- a/src/selection_edge.h
+++ b/src/selection_edge.h
@@ -33,6 +33,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 void selectionEdgeCreate(void);
-void selectionEdgeDestroy(void);
 void selectionEdgeDraw(void);
 void selectionEdgeMotionDraw(int, int, int, int);
+void selectionEdgeDestroy(void);

--- a/src/slist.h
+++ b/src/slist.h
@@ -30,7 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sys/queue.h>
 
 typedef struct ScrotListNode {
-    void* data;
+    void *data;
     STAILQ_ENTRY(ScrotListNode) nodes;
 } ScrotListNode;
 
@@ -41,8 +41,8 @@ typedef STAILQ_HEAD(ScrotLists, ScrotListNode) ScrotList;
     STAILQ_INIT(&name);
 
 #define appendToScrotList(name, newData) do {       \
-    ScrotListNode* node = calloc(1, sizeof(*node)); \
-    node->data = (void*)newData;                    \
+    ScrotListNode *node = calloc(1, sizeof(*node)); \
+    node->data = (void *)newData;                    \
     STAILQ_INSERT_TAIL(&name, node, nodes);         \
 } while(0)
 
@@ -59,7 +59,7 @@ typedef STAILQ_HEAD(ScrotLists, ScrotListNode) ScrotList;
     STAILQ_NEXT(name, nodes);
 
 #define nextAndFreeScrotList(name) do {         \
-    ScrotListNode* next = nextScrotList(name);  \
+    ScrotListNode *next = nextScrotList(name);  \
     free(name);                                 \
     name = next;                                \
 } while(0)

--- a/src/util.c
+++ b/src/util.c
@@ -23,7 +23,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#include "scrot.h"
+#include <err.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "util.h"
 
 char *estrdup(const char *str)
 {


### PR DESCRIPTION
![2021-12-09_1920x540-TEST](https://user-images.githubusercontent.com/25590950/145457050-1c03ba59-9dac-4692-a1c9-185433a6f65f.png)

This is a big change and it's doing a lot, I don't expect it to be perfect, but here's a summary and the idea:

- rename src/main.c to src/scrot.c

This isn't merely a pick on the filename. We have a src/scrot.h file (which is also the main offender for the tangled headers) containing the declarations of main.c (among others). To follow the typical C organization where a header's filename only differs from its corresponding .c file in the extension, either scrot.h needed to become main.h or main.c needed to become scrot.c. I follow the convention of naming the source file containing main() after the project, so I renamed main.c to scrot.c.

This actually included touching a few comments which mentioned a "main.c" file.

- untangle src/scrot.h

This file declared pretty much all of the scrot.c functions, which mostly aren't used in other source files, and it also declared functions and globals belonging to other source files (like initXandImlib() and disp from src/imlib.c).
I initially tried removing function declarations one by one and seeing where they were missed and where they were defined until I realized what was going on exactly, and then I simply deleted every single line in the file and rewrote it from scratch. For this reason, I consider that every line in the file is original and now it only contains my copyright.

- untangle all the other headers

With src/scrot.h previously being the central file holding system/Imlib/X11/scrot #includes, the other headers included it to get what they needed, and incidentally they also got a lot of extra baggage.

The most important effect of this is that now the interactions between scrot's source files are strictly defined in code through the headers.
Because the headers only export what other source files call and nothing more, it's easy to know what code can be touched without affecting other source files.
This change has also made the fact that a lot of functions aren't used elsewhere obvious. I noticed it while working on options.c, and I immediately declared showUsage() and showVersion() static and moved them closer to where they are used. I soon realized there was a whole host of other functions that could be made static, so I decided it was out of scope for this patch and left them as they are for now. Every function that is not declared in a header should be made static after this patch, and only functions that are used in other .c files should be declared in a header.

- make every source file include its own header

When your .c file doesn't include its own header, you run into the possibility of a function declaration used by other source files not matching its definition in the .c file. Maintaining this is brittle and requires human oversight which is prone to human error, and failure to do so can invoke undefined behavior.

When your source file includes its own header, the compiler can warn you of mismatching types between declaration and definition.

- remove the AX_PREFIX_CONFIG_H macro from configure.ac

I did it because I considered this part of untangling headers. The macro created a copy of src/config.h with the name src/scrot_config.h.
Here's the autotools documentation of the macro: https://www.gnu.org/software/autoconf-archive/ax_prefix_config_h.html

To quote the documentation, the macro is used to "Generate an installable config.h." And "A package should not normally install its config.h as a system header, but if it must, this macro can be used to avoid namespace pollution by making a copy of config.h with a prefix added to all the macro names."
scrot isn't a library and we don't install our header, so I removed it.

Code using the C macros provided by autotools should #include "config.h" now, and the parts of the code that do have been updated to match this.

- create a src/imlib.h header corresponding to src/imlib.c

All of imlib.c's declarations were in scrot.h, so it didn't have its own header. Now that scrot.h doesn't do the business of other source files, I created a src/imlib.h. The comments that were near the declarations of imlib.c's globals were moved to imlib.c.

- make every .h file #include what it needs

When I proposed following the WebKit style in scrot, I tried automatically converting the source, but then I noticed that this introduced a compilation failure (and only after I sent the patch, whoops). clang-format sorted the #includes alphabetically, but the headers depended in their order of inclusion, and this shouldn't happen.
It happened because not all headers #included what they needed, and they happened to get it from other headers when a .c file #included them.

Now all the headers #include only what they need to get the types in their declarations, they have only what they need and nothing more, so scrot headers can't depend on a specific order of inclusion anymore.

- make every .c file #include what it needs

Again, previously, everything was #included through scrot.h. An obvious bug that could arise from this is deleting an #include from scrot.h and later finding out that an unrelated .c file breaks. This shouldn't happen.

The inclusion order I used is "<sys/*> headers -> C/POSIX/BSD headers -> libraries -> local headers" with each group of headers alphabetically sorted and separated by a blank line.

- misc small changes

I deleted some whitespace and the "This file is part of the scrot project" comments. I also organized the list of sourced files in src/Makefile.am a bit better.




I've build tested this change on OpenBSD and I've tested the resulting binary after the changes with this command line:
```
./scrot '%Y-%m-%d_$wx$h-TEST.png' -e 'cp $f out.png' -s -d 2 -f -c -b -l style=dash,width=3,color="red" -p -o -n "-f '/usr/X11R6/lib/X11/fonts/TTF/DejaVuSans.ttf/40' -x 10 -y 20 -c 255,0,0,255 -t 'Hi'"
```
I got the command line from:
https://marc.info/?l=openbsd-ports&m=161139638513700&w=2
I made a small change to it, the resulting png file is not moved but copied, so you can check if the formatted filename looks right.
As you can see, it tries a lot of options at the same time, to exercise the most code possible. We don't have automated testing so it should be done by hand.
I'm annexing the screenshot taken by that command in the PR.

You can use that command to test the patch on your system by changing "/usr/X11R6/lib/X11/fonts/TTF/DejaVuSans.ttf" to the path of any font if you don't have a font in that exact path.