### PR TITLE
rewrite autogen.sh to handle its args strictly

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,57 +1,46 @@
-#!/bin/sh
+#!/bin/sh -e
 
-# autogen.sh with clean option, v0.1-scrot
-# Copyright 2019 Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
+# Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
 #
-# This file is under BSD-3-Clause license.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions
-# are met:
-# 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-# 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the distribution.
-# 3. Neither the name of the authors nor the names of its contributors
-#    may be used to endorse or promote products derived from this software
-#    without specific prior written permission.
+# The above copyright notice and this permission notice shall be included in
+# all copies of the Software and its documentation and acknowledgment shall be
+# given in the documentation and software packages that this Software was
+# used.
 #
-# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-# SUCH DAMAGE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
-# Use clean option
-if [ "$1" = "clean" ] && [ ! -e Makefile ]
-then
-    echo "Vanishing the code"
-    rm -rf aclocal.m4 autom4te.cache/ compile configure depcomp install-sh \
-           Makefile.in missing src/config.h.in src/Makefile.in
-    exit 0
-fi
-
-# Do not use clean option
-if [ "$1" = "clean" ] && [ -e Makefile ]
-then
-    echo "I can not clean. Use '$ make distclean'."
-    exit 0
-fi
-
-# Do autoreconf
-autoreconf -i \
-   && { echo " "; \
-        echo "Done. You can use the 'clean' option to vanish the source code."; \
-        echo "Example of use: $ ./autogen.sh clean"; \
-        echo " "; \
-        echo "Now run ./configure, make, and make install."; \
-      } \
-|| { echo "We have a problem..."; exit 1; }
+case "$*" in
+    clean)
+        if [ -e Makefile ]; then
+            printf "Cannot clean. Run \`make distclean\` first.\n" >&2
+            exit 1
+        else
+            printf "Cleaning up.\n"
+            rm -rf aclocal.m4 autom4te.cache/ compile configure depcomp \
+                   install-sh Makefile.in missing src/config.h.in       \
+                   src/Makefile.in
+        fi
+        ;;
+    '')
+        autoreconf -i
+        printf '%s: done.\n' "${0##*/}"
+        printf "Run '\$ ./configure && make && make install' to install.\n"
+        printf "Or run '\$ ./autogen.sh clean' to clean up.\n"
+        ;;
+    *)
+        printf 'Invalid command: %s\n' "$*" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
As it currently stands in the master branch, the autogen.sh script is very liberal with its arguments.

For instance, If you run `./autogen.sh clean trailing garbage`, it ignores the arguments `$2` and `$3` (`trailing` and `garbage`). A more important issue is that if `$1` is anything but `clean`, it runs `autoreconf -i`. One can imagine someone accidentally running `autoreconf -i` because `clean` was mistyped.

I rewrote the script to be strict, its argument list is exactly either empty or the string `clean`, otherwise it returns error. Additionally, the new script makes use of `printf` rather than `echo`. POSIX seems to recommend strongly against `echo`, as the RATIONALE sections of [printf](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html) and [echo](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html) explain.

I'm claiming sole authorship because I rewrote it and putting it under the same license as the rest of the project, but I'd like to know whether @eribertomota agrees/disagrees with this before asking for it to be merged, so I'm leaving the PR a draft for now.