### PR TITLE
build: respect docdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,9 +34,9 @@ MAINTAINERCLEANFILES = Makefile.in
 
 man_MANS = man/scrot.1
 
-doc_DATA = README.md AUTHORS ChangeLog doc/scrot.png
+dist_doc_DATA = README.md AUTHORS ChangeLog doc/scrot.png
 
-EXTRA_DIST = man/scrot.1
+EXTRA_DIST = $(man_MANS)
 
 SUBDIRS = src
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,10 +34,9 @@ MAINTAINERCLEANFILES = Makefile.in
 
 man_MANS = man/scrot.1
 
-docs_DATA = README.md AUTHORS ChangeLog doc/scrot.png
-docsdir = $(prefix)/share/doc/scrot
+doc_DATA = README.md AUTHORS ChangeLog doc/scrot.png
 
-EXTRA_DIST = man/scrot.1 $(docs_DATA)
+EXTRA_DIST = man/scrot.1
 
 SUBDIRS = src
 


### PR DESCRIPTION
Before this patch with --docdir=/usr/share/doc/scrot-1.7-r1 (example downstream
versioning for patches):
```
>>> /usr/share/doc/scrot-1.7-r1/
>>> /usr/share/doc/scrot-1.7-r1/README.md.bz2
>>> /usr/share/doc/scrot-1.7-r1/ChangeLog.bz2
>>> /usr/share/doc/scrot-1.7-r1/AUTHORS.bz2
>>> /usr/share/doc/scrot/
>>> /usr/share/doc/scrot/scrot.png
>>> /usr/share/doc/scrot/README.md.bz2
>>> /usr/share/doc/scrot/ChangeLog.bz2
>>> /usr/share/doc/scrot/AUTHORS.bz2
```

After:
```
>>> /usr/share/doc/scrot-1.7-r1/scrot.png
>>> /usr/share/doc/scrot-1.7-r1/README.md.bz2
>>> /usr/share/doc/scrot-1.7-r1/ChangeLog.bz2
>>> /usr/share/doc/scrot-1.7-r1/AUTHORS.bz2
```

This avoids installing duplicate files & installs them to the
same location but it's overridable by --docdir in ./configure which
helps downstreams.

Bug: https://bugs.gentoo.org/828928
Signed-off-by: Sam James <sam@gentoo.org>