### PR TITLE
Call XFlush after XUngrabServer

### DIFF
--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -85,6 +85,7 @@ void selectionClassicDestroy(void)
         XFreeGC(disp, pc->gc);
 
     free(pc);
+    XFlush(disp);
 }
 
 void selectionClassicDraw(void)


### PR DESCRIPTION
Fix "--count --delay" rendering issue when not showing counting progress in terminal.

This happens when using the "--freeze" option and the "hide/hole/blur" selection modes with the classic line style.

In this scenario, the "--freeze" option acts twice, generating the failure.