### PR TITLE
small CI revamp

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,10 @@ common_template: &common_script
   build_script:
     - ./autogen.sh
     - ./configure
+    - make distcheck
+  test_script:
     - make
+    - src/scrot -v
   on_failure:
     autotools_artifacts:
      path: config.log
@@ -46,7 +49,7 @@ task:
       - CC: clang
       - CC: gcc
   install_script:
-    - apk add autoconf automake make pkgconfig clang gcc xorg-server-dev
+    - apk add autoconf automake gzip make pkgconfig clang gcc xorg-server-dev
               libxcomposite-dev libxext-dev libxfixes-dev imlib2-dev musl-dev
               bsd-compat-headers
   << : *common_script
@@ -91,7 +94,9 @@ task:
 
 task:
   macos_instance:
-    image: big-sur-base
+    # Keep updated with the newest release from
+    # https://cirrus-ci.org/guide/macOS/
+    image: monterey-base
   env:
     OS: macos
     matrix:

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -1,35 +1,57 @@
 # Copyright 2020 Daniel T. Borelli <daltomi@disroot.org>
 # Copyright 2020 Jeroen Roovers <jer@gentoo.org>
 # Copyright 2020 Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
-# Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
+# Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 name: full-check
 
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  ubuntu:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.4.0
     - name: install_dependencies
-      run: sudo apt install libimlib2-dev libxcomposite-dev libxfixes-dev libbsd-dev
-    - name: first_build
       run: |
-           ./autogen.sh
-           ./configure
-           make
-           sudo make install
-           sudo make uninstall
-           make distclean
-    - name: second_build
+        sudo apt install libimlib2-dev libxcomposite-dev libxfixes-dev \
+             libbsd-dev
+    - name: distcheck
       run: |
-           ./autogen.sh
-           ./configure
-           make
-           sudo make install
+        ./autogen.sh
+        ./configure
+        make distcheck
     - name: run_program
       run: |
-           scrot -v
+        make
+        src/scrot -v
+  cygwin:
+    runs-on: windows-latest
+    env:
+      CYGWIN_NOWINPATH: 1 # Removes non-Cygwin dirs from PATH.
+      CHERE_INVOKING: '' # Makes Cygwin's `bash.exe --login` not cd.
+    defaults:
+      run:
+        shell: C:\cygwin\bin\bash.exe --login -o igncr {0}
+    steps:
+    - run: git config --global core.autocrlf input
+      # This is NOT the Cygwin bash, it's the Git for Windows bash from the
+      # default Github Actions Windows VM. This step tells git to translate Unix
+      # newlines to DOS newlines.
+      shell: bash
+    - uses: actions/checkout@v2.4.0
+    - uses: cygwin/cygwin-install-action@v1
+      with:
+        packages: autoconf automake gcc-core libImlib2-devel \
+                  libXcomposite-devel libXext-devel libXfixes-devel make
+    - name: distcheck
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        ./autogen.sh
+        ./configure
+        make distcheck
+    - name: run_program
+      run: |
+        cd ${GITHUB_WORKSPACE}
+        make
+        src/scrot -v


### PR DESCRIPTION
- Add Cygwin to the CI

This is mainly to test portability further.
Cygwin uses the newlib libc on top of Windows. The newlib libc implements a lot of BSD functions. It's a weird platform so maybe it'll catch a bug in the future.

- Add distcheck CI target

I noticed that in PR #175 @daltomi noticed the PR broke `make distcheck`, this could have been caught by the CI, now it will. I also noticed that the Github Actions CI was doing almost all of https://www.gnu.org/software/automake/manual/html_node/Checking-the-Distribution.html by hand, so the lines were deleted as `make distcheck` now fills their role.

- Bring the Cirrus CI in line with Github Actions

The Cirrus actions I wrote didn't run `scrot -v` or do the equivalent of `make distcheck`, now they do. I had to add the gzip package to the Alpine Linux VM as distcheck depends on it.

- Update MacOS version in Cirrus CI

- Update actions/checkout in Github Actions CI