### PR TITLE
add link time optimization and warnings by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,9 +49,10 @@ task:
       - CC: clang
       - CC: gcc
   install_script:
-    - apk add autoconf automake gzip make pkgconfig clang gcc xorg-server-dev
-              libxcomposite-dev libxext-dev libxfixes-dev imlib2-dev musl-dev
-              bsd-compat-headers
+    - apk add autoconf autoconf-archive automake binutils gzip make pkgconfig
+                       gcc clang xorg-server-dev libxcomposite-dev libxext-dev
+                       libxfixes-dev imlib2-dev musl-dev bsd-compat-headers
+                       libbsd-dev llvm-dev
   << : *common_script
 
 task:
@@ -72,8 +73,8 @@ task:
       - CC: gcc
   install_script:
     - apt-get update
-    - apt-get install -y autoconf make pkg-config clang gcc libx11-dev
-                         libxcomposite-dev libxext-dev libxfixes-dev
+    - apt-get install -y autoconf autoconf-archive make pkg-config $CC
+                         libx11-dev libxcomposite-dev libxext-dev libxfixes-dev
                          libimlib2-dev libbsd-dev
   << : *common_script
 
@@ -88,8 +89,8 @@ task:
       - CC: clang
       - CC: gcc
   install_script:
-    - pkg install -y autoconf automake pkgconf gcc libX11 libXcomposite libXext
-                     libXfixes imlib2
+    - pkg install -y autoconf autoconf-archive automake pkgconf gcc libX11
+                     libXcomposite libXext libXfixes imlib2
   << : *common_script
 
 task:
@@ -104,6 +105,6 @@ task:
       - CC: gcc
   install_script:
     - brew update
-    - brew install autoconf automake make pkg-config gcc libx11 libxcomposite
-                   libxext libxfixes imlib2
+    - brew install autoconf autoconf-archive automake make pkg-config gcc libx11
+                   libxcomposite libxext libxfixes imlib2
   << : *common_script

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -15,7 +15,7 @@ jobs:
     - name: install_dependencies
       run: |
         sudo apt install libimlib2-dev libxcomposite-dev libxfixes-dev \
-             libbsd-dev
+             autoconf-archive libbsd-dev
     - name: distcheck
       run: |
         ./autogen.sh
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v2.4.0
     - uses: cygwin/cygwin-install-action@v1
       with:
-        packages: autoconf automake gcc-core libImlib2-devel \
+        packages: autoconf autoconf-archive automake gcc-core libImlib2-devel \
                   libXcomposite-devel libXext-devel libXfixes-devel make
     - name: distcheck
       run: |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If you are interested in helping scrot, read the [CONTRIBUTING.md](CONTRIBUTING.
 scrot requires a few projects and libraries:
 
 - [autoconf](https://www.gnu.org/software/autoconf/autoconf.html) (build time only)
+- [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) (build time only)
 - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (build time only)
 - [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
 - [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --without-libbsd; make` fails)

--- a/configure.ac
+++ b/configure.ac
@@ -1,17 +1,27 @@
 dnl Process this file with autoconf to create configure.
 
-AC_INIT([scrot], [1.7], [https://github.com/resurrecting-open-source-projects/scrot/issues],
-		[],[https://github.com/resurrecting-open-source-projects/scrot])
+AC_INIT([scrot], [1.7],
+        [https://github.com/resurrecting-open-source-projects/scrot/issues],,
+        [https://github.com/resurrecting-open-source-projects/scrot])
 AC_CONFIG_SRCDIR([src/scrot.c])
 AM_INIT_AUTOMAKE(dist-bzip2)
 AC_CONFIG_HEADERS([src/config.h])
 
 # Checks for programs.
+orig_CFLAGS="${CFLAGS}" # Save CFLAGS before AC_PROG_CC sets them.
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
 AM_MAINTAINER_MODE
+
+m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])
+AS_IF([test "x$orig_CFLAGS" = "x"], [
+    CFLAGS=""
+    SCROT_FLAGS="-O2 -flto -g -Wall -Wextra -Wpedantic"
+    AX_APPEND_COMPILE_FLAGS(["$SCROT_FLAGS"])
+    AX_APPEND_LINK_FLAGS(["$SCROT_FLAGS"])
+])
 
 # Checks for libraries.
 PKG_CHECK_MODULES([X11], [x11])
@@ -42,7 +52,7 @@ AC_CHECK_HEADERS([stdint.h sys/time.h unistd.h])
 
 # Required: Checks for library functions.
 AC_CHECK_FUNCS([getopt_long getsubopt gethostname select strdup strerror strndup strtol],,
-	AC_MSG_ERROR([required functions are not present.]))
+    AC_MSG_ERROR([required functions are not present.]))
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Quoting
[GCC Documentation](https://gcc.gnu.org/wiki/LinkTimeOptimization):
> Link Time Optimization (LTO) gives GCC the capability of dumping its
> internal representation (GIMPLE) to disk, so that all the different
> compilation units that make up a single executable can be optimized as
> a single module. This expands the scope of inter-procedural
> optimizations to encompass the whole program (or, rather, everything
> that is visible at link time).

It also has the nice side effect of allowing warnings across translation
units, as attested by these internet blogs:
[gcc 8: link time and interprocedura optimization](https://hubicka.blogspot.com/2018/06/gcc-8-link-time-and-interprocedural.html)
[gnu link time optimization finds non-matching declarations](https://mcuoneclipse.com/2018/05/31/gnu-link-time-optimization-finds-non-matching-declarations/)
> A new user-visible feature is warning about type mismatches across
> units.

Some Linux distros are migrating towards enabling it by default for all
packages, as [Phoronix](https://www.phoronix.com/scan.php?page=news_item&px=Ubuntu-21.04-LTO-Packages) claims. Some OSes (like OpenBSD) don't touch the compile flags of their packages though, so we should do it ourselves.

This change adds autoconf-archive back as a dependency because I used autoconf-archive macros to get it done. Sorry, I only had the idea after the commit that removed it was pushed to master.

This change replaces the CFLAGS with "-O2 -flto -g" and appends the same flags to LDFLAGS (LTO requires this) if the user hasn't set CFLAGS, effectively changing AC_PROG_CC's default of "-O2 -g". I checked out scrot 1.6, 1.7, and commit 6d299f5 (current master as of writing this), and compiled all 3 of them with CFLAGS='-O2', copying each resulting binary to /tmp/. Then I compiled 6d299f5 with CFLAGS='-O2 -flto' to show the difference made by this change:

```console
$ size /tmp/scrot-*
text    data    bss     dec     hex
45417   2952    392     48761   be79    /tmp/scrot-1.6
43724   3232    208     47164   b83c    /tmp/scrot-1.7
42592   3168    208     45968   b390    /tmp/scrot-6d299f5
39649   2880    200     42729   a6e9    /tmp/scrot-6d299f5-flto
```

There's an overall trend with scrot getting 5% smaller with all the cleanups that have been made so far, and now LTO on top of 6d299f5 reduces the binary by a further 7% for a total 12% reduction in binary size. LTO and code quality aren't purely there for smaller binaries, but smaller executables are an easy way to notice them.

I also turned on all warnings by default.