### PR TITLE
remove i386 ifdef

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,6 +105,9 @@ task:
       - CC: gcc
   install_script:
     - brew update
-    - brew install autoconf autoconf-archive automake make pkg-config gcc libx11
-                   libxcomposite libxext libxfixes imlib2
+    - brew install autoconf autoconf-archive automake make meson pkg-config gcc
+                   samurai libx11 libxcomposite libxext libxfixes imlib2 git
+    # libobsd is needed on OS X, but it's not packaged by Brew.
+    - git clone -b v1.1.1 --depth 1 https://github.com/guijan/libobsd
+    - meson setup -Dprovide_libbsd=true build libobsd && meson install -C build
   << : *common_script

--- a/configure.ac
+++ b/configure.ac
@@ -30,9 +30,19 @@ PKG_CHECK_MODULES([XEXT], [xext])
 PKG_CHECK_MODULES([XFIXES], [xfixes])
 PKG_CHECK_MODULES([IMLIB2], [imlib2])
 
+# NetBSD needs _OPENBSD_SOURCE defined to provide reallocarray().
+AC_MSG_CHECKING([Determining host operating system])
+OS=`uname -s`
+AC_MSG_RESULT($OS)
+AS_IF([test "x$OS" = "xNetBSD"], [
+       CPPFLAGS="$CPPFLAGS -D_OPENBSD_SOURCE"
+])
+
+# libbsd provides our BSD functions where they're missing.
 AC_ARG_WITH([libbsd],
     AS_HELP_STRING([--without-libbsd], [Error when BSD functions are not found]))
-AC_CHECK_FUNCS([strlcpy strlcat err errx warn warnx],, [LIBBSD_NEEDED=yes])
+AC_CHECK_FUNCS([reallocarray strlcpy strlcat err errx warn warnx],,
+    [LIBBSD_NEEDED=yes])
 AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes])
 AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
     AS_IF([test "x$with_libbsd" = "xno"], [

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -413,7 +413,7 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     DATA32 *pixels;
     size_t i;
 
-    if ((pixels = reallocarray(NULL, width * height, sizeof(pixels))) == NULL)
+    if ((pixels = reallocarray(NULL, width * height, sizeof(*pixels))) == NULL)
         err(EXIT_FAILURE, "reallocarray");
     /*
      * Copy (unsigned long *)xcim->pixels into (DATA32 *)pixels by assignment


### PR DESCRIPTION
I finally understood what that #ifdef was: it was a micro optimization.
The #ifdef avoids a copy if xcim->pixels happens to be uint32, this is
the case on 32-bit Unix. That's the last #ifdef in scrot being removed.
I want to do this because it's easier to make sure scrot works on
various platforms if they're all running the same code.

This also adds a dependency on my libobsd library under OS X because
scrot now uses reallocarray() which isn't provided by OS X. My library
isn't packaged by Brew.