### PR TITLE
remove VLA and imlib2's deprecated DATA32 type

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -396,29 +396,23 @@ Window scrotGetWindow(Display *display, Window window, int x, int y)
     return target;
 }
 
-
 void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     const int yOffset)
 {
     XFixesCursorImage *xcim = NULL;
-    unsigned short width;
-    unsigned short height;
-    int x;
-    int y;
-    size_t pixcnt;
     uint32_t *pixels = NULL;
     Imlib_Image imcursor;
-
     /* Get the X cursor and the information we want. */
     if ((xcim = XFixesGetCursorImage(disp)) == NULL) {
         warnx("Can't get the cursor from X");
         goto end;
     }
-    width = xcim->width;
-    height = xcim->height;
-    x = (xcim->x - xcim->xhot) - xOffset;
-    y = (xcim->y - xcim->yhot) - yOffset;
-    pixcnt = (size_t)width*height;
+    const unsigned short width = xcim->width;
+    const unsigned short height = xcim->height;
+    const int x = (xcim->x - xcim->xhot) - xOffset;
+    const int y = (xcim->y - xcim->yhot) - yOffset;
+    const size_t pixcnt = (size_t)width*height;
+
     /* xcim->pixels wouldn't be valid if sizeof(*pixels)*pixcnt wrapped around.
      */
     if ((pixels = malloc(sizeof(*pixels)*pixcnt)) == NULL) {

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -401,7 +401,6 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
 {
     XFixesCursorImage *xcim = NULL;
     uint32_t *pixels = NULL;
-    Imlib_Image imcursor;
     /* Get the X cursor and the information we want. */
     if ((xcim = XFixesGetCursorImage(disp)) == NULL) {
         warnx("Can't get the cursor from X");
@@ -409,8 +408,6 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     }
     const unsigned short width = xcim->width;
     const unsigned short height = xcim->height;
-    const int x = (xcim->x - xcim->xhot) - xOffset;
-    const int y = (xcim->y - xcim->yhot) - yOffset;
     const size_t pixcnt = (size_t)width*height;
 
     /* xcim->pixels wouldn't be valid if sizeof(*pixels)*pixcnt wrapped around.
@@ -423,13 +420,15 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     /* Convert an X cursor into the format imlib wants. */
     for (size_t i = 0; i < pixcnt; i++)
             pixels[i] = xcim->pixels[i];
-    imcursor = imlib_create_image_using_data(width, height, pixels);
+    Imlib_Image imcursor = imlib_create_image_using_data(width, height, pixels);
     if (!imcursor) {
         warnx("Can't create cursor image");
         goto end;
     }
 
     /* Overlay the cursor into `image`. */
+    const int x = (xcim->x - xcim->xhot) - xOffset;
+    const int y = (xcim->y - xcim->yhot) - yOffset;
     imlib_context_set_image(imcursor);
     imlib_image_set_has_alpha(1);
     imlib_context_set_image(image);


### PR DESCRIPTION
@N-R-K pointed out the deprecated type and revived interest in removing
the only usage of a VLA in this project.

See the discussion after #193 was merged.
I've tested taking a screenshot with and without a mouse cursor after applying this change, it worked fine.