### PR TITLE
Error on negative number when non-negative required

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -117,7 +117,9 @@ range_error:
 
 static int nonNegativeNumber(int number)
 {
-    return (number < 0) ? 0 : number;
+    if (number < 0)
+        errx(EXIT_FAILURE, "error: non-negative number required (got %d)", number);
+    return number;
 }
 
 int optionsParseRequireRange(int n, int lo, int hi)


### PR DESCRIPTION
Instead of silently pretending the user passed zero, let's issue an error message and bail out.