### PR TITLE
Automake: Use default compression format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ AC_INIT([scrot], [1.7],
         [https://github.com/resurrecting-open-source-projects/scrot/issues],,
         [https://github.com/resurrecting-open-source-projects/scrot])
 AC_CONFIG_SRCDIR([src/scrot.c])
-AM_INIT_AUTOMAKE(dist-bzip2)
+AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([src/config.h])
 
 # Checks for programs.


### PR DESCRIPTION
Remove the forced bzip2 format and use only the default: gzip

Doc: make dist

Generate a ‘gzip’ tar archive of the distribution.
This is the only format enabled by default. 
By default, this rule makes gzip use a compression option of --best.
To make it use a different one, set the GZIP_ENV environment variable.
For example, ‘make dist-gzip GZIP_ENV=-7’.