### PR TITLE
.cirrus.yml: Update MacOS CI and copyright year

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-# Copyright (C) 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
+# Copyright (C) 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -97,7 +97,7 @@ task:
   macos_instance:
     # Keep updated with the newest release from
     # https://cirrus-ci.org/guide/macOS/
-    image: monterey-base
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
   env:
     OS: macos
     matrix:


### PR DESCRIPTION
`git blame` says I touched that file in 2022 too and forgot to update the copyright year, so I'm adding 2022 and 2023.

This fixes the recent MacOS build failures.