### PR TITLE
fix libbsd feature test confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ scrot requires a few projects and libraries:
 - [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) (build time only)
 - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (build time only)
 - [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
-- [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --enable-libbsd-feature-testing` returns true)
+- [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --enable-libbsd-feature-test` returns true)
 - X [(e.g. X.Org)](https://www.x.org/wiki/)
 - libXcomposite [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxcomposite)
 - libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ scrot requires a few projects and libraries:
 - [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) (build time only)
 - [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (build time only)
 - [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
-- [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --without-libbsd; make` fails)
+- [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --enable-libbsd-feature-testing` returns true)
 - X [(e.g. X.Org)](https://www.x.org/wiki/)
 - libXcomposite [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxcomposite)
 - libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)

--- a/configure.ac
+++ b/configure.ac
@@ -31,14 +31,25 @@ PKG_CHECK_MODULES([XFIXES], [xfixes])
 PKG_CHECK_MODULES([XINERAMA], [xinerama])
 PKG_CHECK_MODULES([IMLIB2], [imlib2])
 
-AC_ARG_WITH([libbsd],
-    AS_HELP_STRING([--without-libbsd], [Error when BSD functions are not found]))
+AC_ARG_ENABLE([libbsd-feature-test],
+    AS_HELP_STRING([--enable-libbsd-feature-test],
+        ["Do not configure the program, return true if libbsd is needed"]))
 AC_CHECK_FUNCS([strlcpy strlcat err errx warn warnx],, [LIBBSD_NEEDED=yes])
 AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes])
-AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
-    AS_IF([test "x$with_libbsd" = "xno"], [
-        AC_MSG_ERROR([BSD functions not found and --without-libbsd was used])
+# libbsd is obligatory on systems that don't have the BSD functions we use.
+# Pass "--enable-libbsd-feature-test" to ./configure, and the configure script
+# will tell you whether the library is a dependency. This option is intended to
+# be used by package maintainers.
+AS_IF([test "x$enable_libbsd_feature_test" = "xyes"],
+    AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
+        AC_MSG_NOTICE([scrot depends on libbsd in the current system])
+	exit 0
+    ], [
+        AC_MSG_NOTICE([scrot does not depend on libbsd in the current system])
+        exit 1
     ])
+)
+AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
     PKG_CHECK_MODULES([LIBBSD], [libbsd-overlay],,
         [AC_MSG_ERROR([BSD functions not found, libbsd is required])])
 ])


### PR DESCRIPTION
Users expressed confusion when using the old "--without-libbsd" configure flag. Some assumed that it compiles scrot without libbsd, but it only made the build script error if libbsd is a dependency. This is useful to package maintainers: it gives them a yes/no answer on whether the library is a dependency on their system.

The old configure flag has been replaced by a more verbose "--enable-libbsd-feature-test".

See: https://github.com/resurrecting-open-source-projects/scrot/issues/208 https://github.com/resurrecting-open-source-projects/scrot/discussions/187

I've tested the yes/no paths using Alpine Linux and OpenBSD.