### PR TITLE
New option: --window

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -4,7 +4,7 @@ NAME
 SYNOPSIS
   scrot [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] [-d SEC] [-e CMD]
         [-F FILE] [-k OPT] [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-S CMD] [-s OPTS]
-        [-t % | WxH] [FILE]
+        [-t % | WxH] [-w NUM] [FILE]
 
 DESCRIPTION
   scrot (SCReenshOT) is a simple command line screen capture utility, it uses
@@ -69,6 +69,8 @@ OPTIONS
                             500x200, 100x0, 0x480.
   -u, --focused             Use the currently focused window.
   -v, --version             Output version information and exit.
+  -w, --window              Window identifier to capture.
+                            Must be a valid identifier (see xwininfo(1)).
   -z, --silent              Prevent beeping.
   -                         Redirection to standard output. The output image
                             format is PNG.
@@ -90,7 +92,7 @@ SPECIAL STRINGS
     $s   The image's size in bytes (ignored when used in the filename).
     $t   The image's file format (ignored when used in the filename).
     $w   The image's width.
-    $W   The name of the window (only for --select and --focused).
+    $W   The name of the window (only for --select, --focused and --window).
     \\n   A literal newline (ignored when used in the filename).
 
   Example:
@@ -181,6 +183,7 @@ NOTE FORMAT
 
 SEE ALSO
   optipng(1)
+  xwininfo(1)
 
 AUTHOR
   scrot was originally developed by Tom Gilbert.

--- a/src/options.h
+++ b/src/options.h
@@ -6,7 +6,7 @@ Copyright 1999-2000 Tom Gilbert <tom@linuxbrit.co.uk,
 Copyright 2009      James Cameron <quozl@us.netrek.org>
 Copyright 2010      Ibragimov Rinat <ibragimovrinat@mail.ru>
 Copyright 2017      Stoney Sauce <stoneysauce@gmail.com>
-Copyright 2019-2022 Daniel T. Borelli <danieltborelli@gmail.com>
+Copyright 2019-2023 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
@@ -74,6 +74,7 @@ struct ScrotOptions {
     char *exec;
     char *display;
     char *note;
+    Window windowId;
     const char *windowClassName;
     char *script;
     int autoselect;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -87,6 +87,8 @@ static Window scrotFindWindowByProperty(Display *, const Window,
                                               const Atom);
 static Imlib_Image stalkImageConcat(ScrotList *, const enum Direction);
 static int findWindowManagerFrame(Window *const, int *const);
+static Imlib_Image scrotGrabWindowById(Window const window);
+
 
 int main(int argc, char *argv[])
 {
@@ -132,6 +134,8 @@ int main(int argc, char *argv[])
             image = scrotGrabShotMonitor();
         else if (opt.autoselect)
             image = scrotGrabAutoselect();
+        else if (opt.windowId != None)
+            image = scrotGrabWindowById(opt.windowId);
         else
             image = scrotGrabShot();
     }
@@ -241,22 +245,27 @@ static size_t scrotHaveFileExtension(const char *filename, char **ext)
     return 0;
 }
 
-static Imlib_Image scrotGrabFocused(void)
+static Imlib_Image scrotGrabWindowById(Window const window)
 {
     Imlib_Image im = NULL;
     int rx = 0, ry = 0, rw = 0, rh = 0;
-    Window target = None;
-    int ignored;
 
-    XGetInputFocus(disp, &target, &ignored);
-    if (!scrotGetGeometry(target, &rx, &ry, &rw, &rh))
+    if (!scrotGetGeometry(window, &rx, &ry, &rw, &rh))
         return NULL;
     scrotNiceClip(&rx, &ry, &rw, &rh);
     im = imlib_create_image_from_drawable(0, rx, ry, rw, rh, 1);
     if (opt.pointer)
         scrotGrabMousePointer(im, rx, ry);
-    clientWindow = target;
+    clientWindow = window;
     return im;
+}
+
+static Imlib_Image scrotGrabFocused(void)
+{
+    Window target = None;
+
+    XGetInputFocus(disp, &target, &(int){0});
+    return scrotGrabWindowById(target);
 }
 
 static Imlib_Image scrotGrabAutoselect(void)


### PR DESCRIPTION
```
It allows to indicate the identifier of the window, value in
hexadecimal, to which to capture.

Ex: 'scrot --window 0x100000c'
```

Ex:
```fish
 set WID $(xwininfo | grep "Window id:" | awk '{print $4}') && scrot --window $WID
```

Required parent branch: 23d587a ("Add delay to all capture options")
