### PR TITLE
Indicate that the value is not an integer

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -149,4 +149,4 @@
 
    For example:
    $ scrot --delay 0.5
-   $ scrot: option --delay: '0.5' is is not an integer
+   $ scrot: option --delay: '0.5' is not an integer

--- a/FAQ
+++ b/FAQ
@@ -76,9 +76,9 @@
  9. Does it support redirection of the screenshot to the standard output?
 
     Yes. For example:
-    '$ scrot -'
-    '$ scrot -> myfile.png'
-    '$ scrot - | pngquant -> myfile.png'
+    $ scrot -
+    $ scrot -> myfile.png
+    $ scrot - | pngquant -> myfile.png
 
 
 10. Is there a default image format in the redirection to the standard
@@ -132,8 +132,21 @@
     The image you are using must have an alpha channel (RGBA).
     You will find out if you do the following:
 
-    '$ file stamp.png' shows the following "8-bit/color RGBA",
-    it has alpha channel,  
+    $ file stamp.png
+    Shows the following "8-bit/color RGBA", it has alpha channel.
 
-    '$ file stamp.png' shows the following "8-bit colormap",
-    does not have alpha channel
+    $ file stamp.png
+    Shows the following "8-bit colormap", does not have alpha channel.
+
+
+18. Why can't I use floating point numbers anymore?
+
+   Until version v1.7 it would silently convert a floating point number
+   to a zero(0). Which is an error since it allowed the user to believe
+   that the value given to the option was correct, when it is not.
+   Since version v1.8, the entered value is indicated with an
+   error 'is not an integer'
+
+   For example:
+   $ scrot --delay 0.5
+   $ scrot: option --delay: '0.5' is is not an integer

--- a/src/options.c
+++ b/src/options.c
@@ -9,7 +9,7 @@ Copyright 2009      James Cameron <quozl@us.netrek.org>
 Copyright 2010      Ibragimov Rinat <ibragimovrinat@mail.ru>
 Copyright 2017      Stoney Sauce <stoneysauce@gmail.com>
 Copyright 2019      Daniel Lublin <daniel@lublin.se>
-Copyright 2019-2022 Daniel T. Borelli <danieltborelli@gmail.com>
+Copyright 2019-2023 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2019      Jade Auer <jade@trashwitch.dev>
 Copyright 2020      Sean Brennan <zettix1@gmail.com>
 Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
@@ -125,7 +125,7 @@ long long optionsParseNum(const char *str, long long min, long long max,
     } else if (*str == '\0') {
         *errmsg = "the null string";
     } else if (*end != '\0') {
-        *errmsg = "not a number";
+        *errmsg = "is not an integer";
     } else if (rval < min) {
         /*
          * rval could be set to 0 due to strtoll() returning error and this

--- a/src/options.c
+++ b/src/options.c
@@ -125,7 +125,7 @@ long long optionsParseNum(const char *str, long long min, long long max,
     } else if (*str == '\0') {
         *errmsg = "the null string";
     } else if (*end != '\0') {
-        *errmsg = "is not an integer";
+        *errmsg = "not an integer";
     } else if (rval < min) {
         /*
          * rval could be set to 0 due to strtoll() returning error and this


### PR DESCRIPTION
Until version v1.7 it would silently convert a floating point number to a zero(0). Which is an error since it allowed the user to believe that the value given to the option was correct, when it is not. Since version v1.8, the entered value is indicated with an error 'is not an integer'.