### PR TITLE
fix scrot --delay drift

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,12 +36,12 @@ bin_PROGRAMS  = scrot
 
 scrot_CPPFLAGS = @CPPFLAGS@
 scrot_LDADD    = @LIBS@
-scrot_SOURCES  = scrot.c scrot.h        \
-imlib.c imlib.h                         \
-note.c note.h                           \
-options.c options.h                     \
-scrot_selection.c scrot_selection.h     \
-selection_classic.c selection_classic.h \
-selection_edge.c selection_edge.h       \
-slist.h                                 \
+scrot_SOURCES  = scrot.c scrot.h                        \
+imlib.c imlib.h                                         \
+note.c note.h                                           \
+options.c options.h options_delay.c options_delay.h     \
+scrot_selection.c scrot_selection.h                     \
+selection_classic.c selection_classic.h                 \
+selection_edge.c selection_edge.h                       \
+slist.h                                                 \
 util.c util.h

--- a/src/options.c
+++ b/src/options.c
@@ -55,6 +55,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "note.h"
 #include "options.h"
 #include "scrot.h"
+#include "options_delay.h"
 #include "scrot_selection.h"
 #include "util.h"
 
@@ -415,6 +416,7 @@ void optionsParse(int argc, char *argv[])
                 errx(EXIT_FAILURE, "option --delay: '%s' is %s", optarg,
                     errmsg);
             }
+            scrotTimerStart();
             break;
         case 'e':
             opt.exec = estrdup(optarg);

--- a/src/options_delay.c
+++ b/src/options_delay.c
@@ -1,0 +1,181 @@
+/*
+
+Copyright 2023 Guilherme Janczak <guilherme.janczak@yandex.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies of the Software and its documentation and acknowledgment shall be
+given in the documentation and software packages that this Software was
+used.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <sys/time.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "options.h"
+
+/* Initialized to invalid fds. */
+static int selfPipe[] = {-1, -1};
+
+static void sigalrm(int, siginfo_t *, void *);
+static void timerEnd(void);
+
+/* scrotTimerStart: start counting seconds. */
+void
+scrotTimerStart(void)
+{
+    struct sigaction act;
+    struct itimerval value = {0};
+
+    /* Ignore repeated attempts to set up. */
+    if (selfPipe[0] != -1)
+        return;
+
+    /* This is the self pipe trick: https://cr.yp.to/docs/selfpipe.html
+     * In C99, due to the limitations of signal handlers, this is the only way
+     * to communicate how many times the signal has been triggered.
+     * In C11, we could use <stdatomic.h>.
+     *
+     * OS X doesn't have pipe2(), so we use pipe() and fcntl().
+     */
+    if (pipe(selfPipe) == -1)
+        err(1, "pipe");
+    fcntl(selfPipe[0], O_NONBLOCK);
+
+    act.sa_sigaction = sigalrm;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = SA_SIGINFO;
+    sigaction(SIGALRM, &act, NULL);
+
+    /* We trigger the signal every second regardless of whether we're counting
+     * down or not. This simplifies the code.
+     */
+    value.it_value.tv_sec = value.it_interval.tv_sec = 1;
+    setitimer(ITIMER_REAL, &value, NULL);
+
+    return;
+}
+
+static void
+sigalrm(int sig, siginfo_t *info, void *unused)
+{
+    int savedErrno;
+
+#if defined(__OpenBSD__)
+    /* OpenBSD's singinfo_t functionality is unimplemented, the structure it
+     * passes is us set to meaningless zeroes. Open an issue or PR if your OS
+     * has the same problem.
+     */
+    info->si_code = SI_TIMER;
+#endif
+    if (info->si_code != SI_TIMER)
+        return; /* Someone gave us a SIGALRM. Ignore it. */
+
+    (void)unused;
+
+    savedErrno = errno;
+    while (write(selfPipe[1], &sig /* Irrelevant value. */, 1) == -1) {
+        if (errno == EINTR)
+            continue;
+
+        /* Hangup the pipe to signal error. The only C99 ways to communicate the
+         * exact errno value would be to pass it through a pipe or write a
+         * kludge that writes it to multiple sig_atomic_t variables and we just
+         * failed to write to a pipe.
+         *
+         * In practice, this will never happen.
+         */
+        close(selfPipe[1]);
+        break;
+    }
+    errno = savedErrno;
+}
+
+/* scrotTimerWait: Wait for the delay, possibly printing a countdown.
+ *
+ * The contdown is only printed if opt.countdown is set.
+ */
+void
+scrotTimerWait(void)
+{
+    struct pollfd pfd;
+    unsigned char unusedBuf;
+
+    if (opt.countdown) {
+        printf("Taking screenshot in %d.. ", opt.delay);
+        fflush(stdout);
+    }
+
+    pfd.fd = selfPipe[0];
+    pfd.events = POLLIN;
+    for (; opt.delay > 0;) {
+        if (poll(&pfd, 1, -1) == -1) {
+            if (errno == EINTR)
+                continue;
+            err(1, "poll");
+        }
+        opt.delay--;
+
+        /*
+         * POSIX allows POLLIN and POLLHUP to be set simultaneously, but dealing
+         * with that theoretical edge case is not worth it, so just error if we
+         * see POLLHUP.
+         */
+        if (pfd.revents & POLLHUP)
+            errx(1, "sigalrm() failed to write to selfPipe");
+
+        if (pfd.revents & POLLIN) {
+            while (read(selfPipe[0], &unusedBuf, 1) == -1) {
+                if (errno == EINTR)
+                    continue;
+                err(1, "read");
+            }
+            if (opt.countdown) {
+                printf("%d.%s ", opt.delay, opt.delay ? "." : "");
+                fflush(stdout);
+            }
+        }
+    }
+    if (opt.countdown)
+        putchar('\n');
+
+    timerEnd();
+}
+
+static void
+timerEnd(void)
+{
+    struct sigaction act;
+    struct itimerval value = {0};
+    setitimer(ITIMER_REAL, &value, NULL);
+
+    act.sa_handler = SIG_DFL;
+    sigemptyset(&act.sa_mask);
+    act.sa_flags = 0;
+    sigaction(SIGALRM, &act, NULL);
+
+    close(selfPipe[0]);
+    close(selfPipe[1]);
+    selfPipe[0] = selfPipe[1] = -1;
+}

--- a/src/options_delay.c
+++ b/src/options_delay.c
@@ -65,7 +65,8 @@ scrotTimerStart(void)
 
     act.sa_sigaction = sigalrm;
     sigemptyset(&act.sa_mask);
-    act.sa_flags = SA_SIGINFO;
+    /* NODEFER guarantees signals aren't discarded. */
+    act.sa_flags = SA_SIGINFO | SA_NODEFER;
     sigaction(SIGALRM, &act, NULL);
 
     /* We trigger the signal every second regardless of whether we're counting

--- a/src/options_delay.h
+++ b/src/options_delay.h
@@ -1,7 +1,5 @@
-/* scrot.h
-
-Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
-Copyright 2022 Daniel T. Borelli <danieltborelli@gmail.com>
+/*
+Copyright 2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -24,15 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-/* Part of the code comes from the scrot.c file and maintains its authorship. */
-
 #pragma once
 
-#include <X11/Xlib.h>
-#include <Imlib2.h>
-
-Window scrotGetWindow(Display *, Window, int, int);
-int scrotGetGeometry(Window, int *, int *, int *, int *);
-void scrotNiceClip(int *, int *, int *, int *);
-void scrotGrabMousePointer(const Imlib_Image, const int, const int);
-char *scrotGetWindowName(Window);
+void scrotTimerStart(void);
+void scrotTimerWait(void);

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -64,6 +64,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "imlib.h"
 #include "note.h"
 #include "options.h"
+#include "options_delay.h"
 #include "scrot.h"
 #include "slist.h"
 #include "util.h"
@@ -115,12 +116,10 @@ int main(int argc, char *argv[])
         scrotHaveFileExtension(opt.outputFile, &haveExtension);
     }
 
-    if (opt.selection.mode & SELECTION_MODE_ANY)
+    if (opt.selection.mode & SELECTION_MODE_ANY) {
         image = scrotSelectionSelectMode();
-    else {
-
-        scrotDoDelay();
-
+    } else {
+        scrotTimerWait();
         if (opt.focused)
             image = scrotGrabFocused();
         else if (opt.multidisp)
@@ -257,27 +256,6 @@ static Imlib_Image scrotGrabAutoselect(void)
     if (opt.pointer)
         scrotGrabMousePointer(im, rx, ry);
     return im;
-}
-
-void scrotDoDelay(void)
-{
-    if (opt.delay) {
-        if (opt.countdown) {
-            int i;
-
-            printf("Taking shot in %d.. ", opt.delay);
-            fflush(stdout);
-            sleep(1);
-            for (i = opt.delay - 1; i > 0; i--) {
-                printf("%d.. ", i);
-                fflush(stdout);
-                sleep(1);
-            }
-            printf("0.\n");
-            fflush(stdout);
-        } else
-            sleep(opt.delay);
-    }
 }
 
 /* Clip rectangle nicely */

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -50,6 +50,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "imlib.h"
 #include "options.h"
+#include "options_delay.h"
 #include "scrot.h"
 #include "scrot_selection.h"
 #include "selection_classic.h"
@@ -466,7 +467,7 @@ Imlib_Image scrotSelectionSelectMode(void)
         if (!scrotSelectionGetUserSel(&rect1))
             return NULL;
 
-    scrotDoDelay();
+    scrotTimerWait();
 
     Imlib_Image capture = imlib_create_image_from_drawable(0, rect0.x, rect0.y,
         rect0.w, rect0.h, 1);


### PR DESCRIPTION
This PR still needs testing, but it's otherwise complete.

It has a workaround for an OpenBSD bug, someone has to check if this bug is present in other operating systems. I can probably bake the logic to check for the bug into the code, but that will have to wait.

Edit: I thought it was possible the other BSDs suffered from the same issue (siginfo_t unimplemented) because they share the same origin, but it's only OpenBSD, so I used a small #ifdef instead of writing the logic to check for the bug