### PR TITLE
Update TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ Look for any bugs reported downstream or in our github issues and fix them:
 - https://github.com/resurrecting-open-source-projects/scrot/issues
 - https://bugs.debian.org/cgi-bin/pkgreport.cgi?dist=unstable;package=scrot
 - https://bugs.launchpad.net/ubuntu/+source/scrot/+bugs
-- https://apps.fedoraproject.org/packages/scrot/bugs
+- https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&component=scrot&product=Fedora
 - https://bugs.gentoo.org/buglist.cgi?quicksearch=scrot
 
 ## Integrate [libbsd](https://libbsd.freedesktop.org/wiki/)
@@ -30,25 +30,3 @@ The following libbsd integration efforts are in progress:
 - ~~Replace error exits with the err() family of functions.~~
 - ~~Replace local implementations of data structures with the sys/queue.h API.~~
 - Find places where other BSD functions can serve scrot well.
-
-## Comply with WebKit style
-We're currently in the process of complying with the new obligatory C style
-described in [CONTRIBUTING.md](CONTRIBUTING.md).
-
-The following files are yet to be converted:
-- ~~src/imlib.c~~
-- ~~src/main.c~~
-- ~~src/note.c~~
-- ~~src/options.c~~
-- ~~src/scrot_selection.c~~
-- ~~src/selection_classic.c~~
-- ~~src/selection_edge.c~~
-- ~~src/note.h~~
-- ~~src/options.h~~
-- ~~src/slist.c~~
-- ~~src/scrot.h~~
-- ~~src/scrot_selection.h~~
-- ~~src/selection_classic.h~~
-- ~~src/selection_edge.h~~
-- ~~src/slist.h~~
-- ~~src/structs.h~~


### PR DESCRIPTION
Fedora seems to have changed the URL of where scrot bugs are reported, switch to the new one.
We already completed the migration to WebKit style, remove that section.