### PR TITLE
Fix unchecked calloc calls

### DIFF
--- a/src/note.c
+++ b/src/note.c
@@ -4,6 +4,7 @@ Copyright 2019-2022 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2023      NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -37,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "note.h"
 #include "options.h"
+#include "util.h"
 
 enum { // default color
     DEF_COLOR_RED = 0,
@@ -102,10 +104,7 @@ void scrotNoteNew(char const *const format)
 
     scrotNoteFree();
 
-    note = calloc(1, sizeof(*note));
-
-    assert(note);
-
+    note = ecalloc(1, sizeof(*note));
     note->color.r = DEF_COLOR_RED;
     note->color.g = DEF_COLOR_GREEN;
     note->color.b = DEF_COLOR_BLUE;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -18,7 +18,7 @@ Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
 Copyright 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      IFo Hancroft <contact@ifohancroft.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
-Copyright 2022      NRK <nrk@disroot.org>
+Copyright 2022-2023 NRK <nrk@disroot.org>
 Copyright 2022      Zev Weiss <zev@bewilderbeest.net>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -469,7 +469,7 @@ static void scrotCheckIfOverwriteFile(char **filename)
     if (ext)
         nalloc += extLength; // .ext
 
-    newName = calloc(nalloc, sizeof(*newName));
+    newName = ecalloc(nalloc, sizeof(*newName));
     memcpy(newName, *filename, slen);
 
     do {

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -5,7 +5,7 @@ Copyright 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Martin C <martincation@protonmail.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2021      Wilson Smith <01wsmith+gh@gmail.com>
-Copyright 2022      NRK <nrk@disroot.org>
+Copyright 2022-2023 NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -54,6 +54,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot_selection.h"
 #include "selection_classic.h"
 #include "selection_edge.h"
+#include "util.h"
 
 struct Selection **selectionGet(void)
 {
@@ -64,7 +65,7 @@ struct Selection **selectionGet(void)
 static void selectionAllocate(void)
 {
     struct Selection **sel = selectionGet();
-    *sel = calloc(1, sizeof(**sel));
+    *sel = ecalloc(1, sizeof(**sel));
 }
 
 static void selectionDeallocate(void)

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -3,6 +3,7 @@
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2023      NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -41,6 +42,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot_selection.h"
 #include "selection_classic.h"
 #include "selection_edge.h"
+#include "util.h"
 
 struct SelectionClassic {
     XGCValues gcValues;
@@ -51,7 +53,7 @@ void selectionClassicCreate(void)
 {
     struct Selection *const sel = *selectionGet();
 
-    sel->classic = calloc(1, sizeof(*sel->classic));
+    sel->classic = ecalloc(1, sizeof(*sel->classic));
 
     struct SelectionClassic *pc = sel->classic;
 

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -3,6 +3,7 @@
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
+Copyright 2023      NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -42,6 +43,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "options.h"
 #include "scrot_selection.h"
 #include "selection_edge.h"
+#include "util.h"
 
 struct SelectionEdge {
     Window wndDraw;
@@ -55,7 +57,7 @@ void selectionEdgeCreate(void)
 {
     struct Selection *const sel = *selectionGet();
 
-    sel->edge = calloc(1, sizeof(*sel->edge));
+    sel->edge = ecalloc(1, sizeof(*sel->edge));
 
     struct SelectionEdge *const pe = sel->edge;
 

--- a/src/slist.h
+++ b/src/slist.h
@@ -3,6 +3,7 @@
 Copyright 2021 Christopher Nelson <christopher.nelson@languidnights.com>
 Copyright 2021 Daniel T. Borelli <danieltborelli@gmail.com>
 Copyright 2021 Peter Wu <peterwu@hotmail.com>
+Copyright 2023 NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -28,6 +29,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #include <sys/queue.h>
+#include "util.h"
 
 typedef struct ScrotListNode {
     void *data;
@@ -41,7 +43,7 @@ typedef STAILQ_HEAD(ScrotLists, ScrotListNode) ScrotList;
     STAILQ_INIT(&name);
 
 #define appendToScrotList(name, newData) do {       \
-    ScrotListNode *node = calloc(1, sizeof(*node)); \
+    ScrotListNode *node = ecalloc(1, sizeof(*node)); \
     node->data = (void *)newData;                    \
     STAILQ_INSERT_TAIL(&name, node, nodes);         \
 } while(0)

--- a/src/util.c
+++ b/src/util.c
@@ -1,6 +1,7 @@
 /* util.c
 
 Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2023 NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -34,5 +35,13 @@ char *estrdup(const char *str)
     char *p;
     if ((p = strdup(str)) == NULL)
         err(EXIT_FAILURE, "strdup");
+    return p;
+}
+
+void *ecalloc(size_t nmemb, size_t size)
+{
+    void *p = calloc(nmemb, size);
+    if (!p)
+        err(EXIT_FAILURE, "calloc");
     return p;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,7 @@
 /* util.h
 
 Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2023 NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -26,3 +27,4 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 char *estrdup(const char *);
+void *ecalloc(size_t, size_t);


### PR DESCRIPTION
This replaces unchecked `calloc` calls with `ecalloc` - a `calloc` wrapper that exits upon failure.