### PR TITLE
Add scrotSleep and use dprintf

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -259,6 +259,17 @@ static Imlib_Image scrotGrabAutoselect(void)
     return im;
 }
 
+/* similar to sleep, but deals with EINTR.
+ * ideally, we'd want to sleep against an absolute time to prevent any drift
+ * but clock_nanosleep doesn't seem to be widely implemented.
+ */
+static void scrotSleep(int sec)
+{
+    assert(sec > 0);
+    struct timespec delay = { .tv_sec = sec };
+    while (nanosleep(&delay, &delay) < 0 && errno == EINTR);
+}
+
 void scrotDoDelay(void)
 {
     if (opt.delay) {
@@ -267,16 +278,16 @@ void scrotDoDelay(void)
 
             printf("Taking shot in %d.. ", opt.delay);
             fflush(stdout);
-            sleep(1);
+            scrotSleep(1);
             for (i = opt.delay - 1; i > 0; i--) {
                 printf("%d.. ", i);
                 fflush(stdout);
-                sleep(1);
+                scrotSleep(1);
             }
             printf("0.\n");
             fflush(stdout);
         } else
-            sleep(opt.delay);
+            scrotSleep(opt.delay);
     }
 }
 

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -276,13 +276,13 @@ void scrotDoDelay(void)
         if (opt.countdown) {
             int i;
 
-            dprintf(STDOUT_FILENO, "Taking shot in %d.. ", opt.delay);
+            dprintf(STDERR_FILENO, "Taking shot in %d.. ", opt.delay);
             scrotSleep(1);
             for (i = opt.delay - 1; i > 0; i--) {
-                dprintf(STDOUT_FILENO, "%d.. ", i);
+                dprintf(STDERR_FILENO, "%d.. ", i);
                 scrotSleep(1);
             }
-            dprintf(STDOUT_FILENO, "0.\n");
+            dprintf(STDERR_FILENO, "0.\n");
         } else
             scrotSleep(opt.delay);
     }

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -276,16 +276,13 @@ void scrotDoDelay(void)
         if (opt.countdown) {
             int i;
 
-            printf("Taking shot in %d.. ", opt.delay);
-            fflush(stdout);
+            dprintf(STDOUT_FILENO, "Taking shot in %d.. ", opt.delay);
             scrotSleep(1);
             for (i = opt.delay - 1; i > 0; i--) {
-                printf("%d.. ", i);
-                fflush(stdout);
+                dprintf(STDOUT_FILENO, "%d.. ", i);
                 scrotSleep(1);
             }
-            printf("0.\n");
-            fflush(stdout);
+            dprintf(STDOUT_FILENO, "0.\n");
         } else
             scrotSleep(opt.delay);
     }


### PR DESCRIPTION
### Introduce scrotSleep() which deals with EINTR

sleep() may end up waking up eariler than requested due to signals. so
use nanosleep() and deal with EINTR in case it happens.

### scrotDoDelay: use dprintf to bypass stdio stream

since we want the output to be immediately shown, using stdio doesn't
make much sense. using dprintf to output straight to the file descriptor
allows us to skip having to manually flush every time.

### scrotDoDelay: output countdown to stderr

otherwise, the countdown won't be visible when user is outputting the
image to stdout. for example commands like the following will end up
with a "corrupted" image due to the countdown being slipping in there.

    scrot -d3 -c - | xclip -in -selection clipboard -target image/png

by outputting the countdown to stderr, the above command will work
properly.

for reference, `maim` also outputs it's countdown to stderr, not stdout.
