### PR TITLE
getopt_long() cleanup

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -393,11 +393,11 @@ void optionsParse(int argc, char *argv[])
         { "monitor", required_argument, 0, 'M'},
         { 0, 0, 0, 0 }
     };
-    int optch = 0, cmdx = 0;
+    int optch = 0;
     const char *errmsg;
 
     /* Now to pass some optionarinos */
-    while ((optch = getopt_long(argc, argv, stropts, lopts, &cmdx)) != -1) {
+    while ((optch = getopt_long(argc, argv, stropts, lopts, NULL)) != -1) {
         switch (optch) {
         case 0:
             break;

--- a/src/options.c
+++ b/src/options.c
@@ -397,7 +397,7 @@ void optionsParse(int argc, char *argv[])
     const char *errmsg;
 
     /* Now to pass some optionarinos */
-    while ((optch = getopt_long(argc, argv, stropts, lopts, &cmdx)) != EOF) {
+    while ((optch = getopt_long(argc, argv, stropts, lopts, &cmdx)) != -1) {
         switch (optch) {
         case 0:
             break;


### PR DESCRIPTION
Noticed these while I was trying to add `--delay-select` for #221 

### options: test against correct return value

getopt_long manpage says:

| If all command-line options have been parsed, then getopt() returns -1.

it doesn't say anything about returning EOF. but since EOF is typically
defined as -1 it ended up working by accident.

### options: remove unused variable

getopt_long accepts NULL as longindex argument, so no need to pass a
dummy variable.
