### PR TITLE
fix multiple bugs in output file handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,8 @@ PKG_CHECK_MODULES([IMLIB2], [imlib2])
 AC_ARG_ENABLE([libbsd-feature-test],
     AS_HELP_STRING([--enable-libbsd-feature-test],
         ["Do not configure the program, return true if libbsd is needed"]))
-AC_CHECK_FUNCS([strlcpy strlcat err errx warn warnx],, [LIBBSD_NEEDED=yes])
+AC_CHECK_FUNCS([strlcpy strlcat err errx getprogname warn warnx],,
+    [LIBBSD_NEEDED=yes])
 AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes])
 # libbsd is obligatory on systems that don't have the BSD functions we use.
 # Pass "--enable-libbsd-feature-test" to ./configure, and the configure script
@@ -43,7 +44,7 @@ AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes])
 AS_IF([test "x$enable_libbsd_feature_test" = "xyes"],
     AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
         AC_MSG_NOTICE([scrot depends on libbsd in the current system])
-	exit 0
+        exit 0
     ], [
         AC_MSG_NOTICE([scrot does not depend on libbsd in the current system])
         exit 1

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -3,8 +3,8 @@ NAME
 
 SYNOPSIS
   scrot [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] [-d SEC] [-e CMD]
-        [-F FILE] [-k OPT] [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-S CMD] [-s OPTS]
-        [-t % | WxH] [-w NUM] [FILE]
+        [-k OPT] [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-S CMD] [-s OPTS]
+        [-t % | WxH] [-w NUM] [[-F] FILE]
 
 DESCRIPTION
   scrot (SCReenshOT) is a simple command line screen capture utility, it uses
@@ -33,7 +33,6 @@ OPTIONS
                             When given the `b` prefix, e.g `-d b8`, the delay
                             will be applied before selection.
   -e, --exec CMD            Execute CMD on the saved image.
-  -F, --file                File name. See SPECIAL STRINGS.
   -f, --freeze              Freeze the screen when -s is used.
   -h, --help                Display help and exit.
   -i, --ignorekeyboard      Don't exit for keyboard input. ESC still exits.
@@ -72,8 +71,11 @@ OPTIONS
   -w, --window              Window identifier to capture.
                             Must be a valid identifier (see xwininfo(1)).
   -z, --silent              Prevent beeping.
-  -                         Redirection to standard output. The output image
-                            format is PNG.
+  -F, --file FILE           Specify the output file. If FILE is "-", scrot will
+                            output a PNG image to stdout. The filename is
+                            expanded according to the format specified in
+                            SPECIAL STRINGS. The output file may be specified
+                            through the -F option, or as a non-option argument.
 
 SPECIAL STRINGS
   -e, -F and FILE parameters can take format specifiers that are expanded

--- a/src/options.h
+++ b/src/options.h
@@ -69,7 +69,7 @@ struct ScrotOptions {
     enum Direction stackDirection;
     char *lineColor;
     char *lineMode;
-    char *outputFile;
+    const char *outputFile;
     char *thumbFile;
     char *exec;
     char *display;
@@ -90,8 +90,6 @@ struct ScrotOptions {
 extern struct ScrotOptions opt;
 
 void optionsParse(int, char **);
-char *optionsNameThumbnail(const char *);
-void optionsParseFileName(const char *);
 void optionsParseAutoselect(char *);
 void optionsParseDisplay(char *);
 void optionsParseNote(char *);

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -80,7 +80,8 @@ static Imlib_Image scrotGrabStackWindows(void);
 static Imlib_Image scrotGrabShot(void);
 static void scrotCheckIfOverwriteFile(char **);
 static void scrotExecApp(Imlib_Image, struct tm *, char *, char *);
-static char *imPrintf(char *, struct tm *, char *, char *, Imlib_Image);
+static char *imPrintf(const char *, struct tm *, const char *, const char *,
+    Imlib_Image);
 static char *scrotGetWindowName(Window);
 static Window scrotGetClientWindow(Display *, Window);
 static Window scrotFindWindowByProperty(Display *, const Window,
@@ -97,8 +98,7 @@ int main(int argc, char *argv[])
     Imlib_Load_Error imErr;
     char *filenameIM = NULL;
     char *filenameThumb = NULL;
-
-    char *haveExtension = NULL;
+    char *haveExtension;
 
     time_t t;
     struct tm *tm;
@@ -108,15 +108,6 @@ int main(int argc, char *argv[])
     optionsParse(argc, argv);
 
     initXAndImlib(opt.display, 0);
-
-    if (!opt.outputFile) {
-        opt.outputFile = estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot.png");
-        opt.thumbFile = estrdup("%Y-%m-%d-%H%M%S_$wx$h_scrot-thumb.png");
-    } else {
-        if (opt.thumb != THUMB_DISABLED)
-            opt.thumbFile = optionsNameThumbnail(opt.outputFile);
-        scrotHaveFileExtension(opt.outputFile, &haveExtension);
-    }
 
     if (opt.selection.mode & SELECTION_MODE_ANY)
         image = scrotSelectionSelectMode();
@@ -150,10 +141,10 @@ int main(int argc, char *argv[])
     tm = localtime(&t);
 
     imlib_context_set_image(image);
-    imlib_image_attach_data_value("quality", NULL, opt.quality, NULL);
-
+    scrotHaveFileExtension(opt.outputFile, &haveExtension);
     if (!haveExtension)
         imlib_image_set_format("png");
+    imlib_image_attach_data_value("quality", NULL, opt.quality, NULL);
 
     filenameIM = imPrintf(opt.outputFile, tm, NULL, NULL, image);
     scrotCheckIfOverwriteFile(&filenameIM);
@@ -196,7 +187,6 @@ int main(int argc, char *argv[])
         if (!thumbnail) {
             errx(EXIT_FAILURE, "unable to create thumbnail");
         } else {
-            scrotHaveFileExtension(opt.thumbFile, &haveExtension);
             imlib_context_set_image(thumbnail);
             if (!haveExtension)
                 imlib_image_set_format("png");
@@ -587,8 +577,8 @@ static Bool scrotXEventVisibility(Display *dpy, XEvent *ev, XPointer arg)
     return (ev->xvisibility.window == *win);
 }
 
-static char *imPrintf(char *str, struct tm *tm, char *filenameIM,
-    char *filenameThumb, Imlib_Image im)
+static char *imPrintf(const char *str, struct tm *tm, const char *filenameIM,
+    const char *filenameThumb, Imlib_Image im)
 {
     char *c;
     char buf[20];


### PR DESCRIPTION
Check the commit message for details.

This the extent of the testing I've done:
```console
$ src/scrot -F test test2
scrot: both the --file option and the FILE parameter were used
$ src/scrot -F test test2 test3
scrot: both the --file option and the FILE parameter were used
$ src/scrot test test2
scrot: extraneous non-option arguments: test2
$ src/scrot test test2 test3 test4
scrot: extraneous non-option arguments: test2 test3 test4
$ src/scrot "$(yes | tr -d '\n' | dd bs=251 count=1 2>/dev/null)".png
$ src/scrot "$(yes | tr -d '\n' | dd bs=256 count=1 2>/dev/null)".png
scrot: Saving to file yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy.png failed: File name too long
```
The last one shows that if we try to create a file with a name over NAME_MAX, imlib will return error without us having to do any checking which is exactly what we want. This PR increases the length limit of the output file's full path to fpathconf()'s idea of PATH_MAX or NAME_MAX, whichever comes first.