### PR TITLE
remove -S flag

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -3,8 +3,8 @@ NAME
 
 SYNOPSIS
   scrot [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] [-d SEC] [-e CMD]
-        [-k OPT] [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-S CMD] [-s OPTS]
-        [-t % | WxH] [-w NUM] [[-F] FILE]
+        [-k OPT] [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-s OPTS] [-t % | WxH]
+        [-w NUM] [[-F] FILE]
 
 DESCRIPTION
   scrot (SCReenshOT) is a simple command line screen capture utility, it uses
@@ -58,7 +58,6 @@ OPTIONS
                             compression. For lossy output formats, a higher
                             value represents higher quality and larger
                             file size. Default: 75.
-  -S, --script CMD          CMD is an imlib2 script.
   -s, --select[=OPTS]       Interactively select a window or rectangle with the
                             mouse, use the arrow keys to resize. See the -l and
                             -f options. OPTS it's optional; see SELECTION MODE

--- a/src/options.c
+++ b/src/options.c
@@ -517,7 +517,7 @@ static void showUsage(void)
     fputs(/* Check that everything lines up after any changes. */
         "usage:  " PACKAGE " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]\n"
         "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM] [-n OPTS]\n"
-        "              [-q NUM] [-S CMD] [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
+        "              [-q NUM] [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
         stdout);
     exit(0);
 }

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -473,6 +473,8 @@ end:
 // It assumes that the local variable 'scrot.c:Imlib_Image image' is in context
 static void applyFilterIfRequired(void)
 {
+    warnx("--script is deprecated. See: "
+        "https://github.com/resurrecting-open-source-projects/scrot/pull/231");
     if (opt.script)
         imlib_apply_filter(opt.script);
 }


### PR DESCRIPTION
Relevant imlib documentation:
https://docs.enlightenment.org/api/imlib2/html/
CTRL+F "Imlib 2 Dynamic Filters"

The -S flag makes imlib filters available to the user. However, it's impossible to do this, because imlib filters can reference variables passed to `imlib_apply_filter()` via varargs, and there's no way in C to pass the right amount of varargs. Look up "[] operator" in the imlib documentation.

Additionally, this option may be the source of a security vulnerability. A malicious imlib script could decrement the stack pointer by using the right amount of imlib script [] operators. Varargs are typically implemented by popping values off the stack. By changing what the stack points to, the values of variables or the return address could be changed, the stack pointer could even be decremented until it points all the way to the argument vector (which is in the stack on Linux at least, I don't know about other platforms) and that is also controlled by the program's caller.

This option is broken, impossible to fix, a possible security vulnerability, and obscure enough that it doesn't necessarily have users, so let's remove it.