### PR TITLE
Simplify getPathOfStdout()

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -631,6 +631,7 @@ static void optionsParseThumbnail(char *optarg)
 void optionsParseFileName(const char *optarg)
 {
     checkMaxOutputFileName(optarg);
+    free(opt.outputFile);
     opt.outputFile = estrdup(optarg);
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -26,5 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
+#define ARRAY_COUNT(X)   (sizeof(X) / sizeof(0[X]))
+
 char *estrdup(const char *);
 void *ecalloc(size_t, size_t);


### PR DESCRIPTION
let the caller duplicate it if needed, allows for passing the return
value straight to optionsParseFileName()

also since STDOUT_FILENO is defined to be 1 there was no need to call
snprintf().

- - -

Includes the mem leak fix from #229