### PR TITLE
clean up optionsNameThumbnail()

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -525,25 +525,19 @@ static void showVersion(void)
 
 char *optionsNameThumbnail(const char *name)
 {
+    const size_t nameLength = strlen(name);
     const char thumbSuffix[] = "-thumb";
-    const size_t newNameLength = strlen(name) + sizeof(thumbSuffix);
-    char *newName = malloc(newNameLength);
-
-    if (!newName)
-        err(EXIT_FAILURE, "Unable to allocate thumbnail");
-
+    Stream ret = {0};
     const char *const extension = strrchr(name, '.');
+    const size_t baseNameLength = extension ? extension-name : nameLength;
 
-    if (extension) {
-        /* We add one so length includes '\0'*/
-        const ptrdiff_t nameLength = (extension - name) + 1;
-        strlcpy(newName, name, nameLength);
-        strlcat(newName, thumbSuffix, newNameLength);
-        strlcat(newName, extension, newNameLength);
-    } else
-        snprintf(newName, newNameLength, "%s%s", name, thumbSuffix);
+    streamMem(&ret, name, baseNameLength);
+    streamMem(&ret, thumbSuffix, sizeof(thumbSuffix)-1);
+    if (extension)
+        streamMem(&ret, extension, nameLength - baseNameLength);
+    streamChar(&ret, '\0');
 
-    return newName;
+    return ret.buf;
 }
 
 void optionsParseAutoselect(char *optarg)


### PR DESCRIPTION
Sorry but this function has been bugging me ever since #220. I knew it could be better but I failed back then.

I've tested it with these commands:
```sh
src/scrot --thumb 50 test.png
src/scrot --thumb 50 test
src/scrot --thumb 50 te.st.png
```
As you can see, all the right files were created:
```console
$ git status
On branch briefer-namethumb
Your branch is up to date with 'origin/briefer-namethumb'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        te.st-thumb.png
        te.st.png
        test
        test-thumb
        test-thumb.png
        test.png

nothing added to commit but untracked files present (use "git add" to track)
```