### PR TITLE
imPrintf: use dynamic buffer and concatenate efficiently

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -27,6 +27,18 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #define ARRAY_COUNT(X)   (sizeof(X) / sizeof(0[X]))
+#define MAX(A, B)        ((A) > (B) ? (A) : (B))
+
+typedef struct {
+    char *buf;
+    size_t off, cap;
+} Stream;
 
 char *estrdup(const char *);
 void *ecalloc(size_t, size_t);
+void *erealloc(void *, size_t);
+
+void streamReserve(Stream *, size_t);
+void streamChar(Stream *, char);
+void streamMem(Stream *, const void *, size_t);
+void streamStr(Stream *, const char *);


### PR DESCRIPTION
The imPrintf function currently is horribly inefficient due to `strlcat` having to recompute `strlen` on _every single call_ [^0].

The requirement of nul-terminator also makes for very awkward code like these:

https://github.com/resurrecting-open-source-projects/scrot/blob/5388fffd7be700834ee888ed129b2325c8ab1ef2/src/scrot.c#L684-L685

Instead just remember where to append, and grow the buffer dynamically if needed (which would enable properly fixing https://github.com/resurrecting-open-source-projects/scrot/issues/223). 

[^0]:  If the standard string copying functions [weren't idiotic](https://www.symas.com/post/the-sad-state-of-c-strings) then strcat (and friends) wouldn't even need to exist.
