### PR TITLE
imPrintf: avoid hostname truncation

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -605,7 +605,7 @@ static char *imPrintf(char *str, struct tm *tm, char *filenameIM,
         errx(EXIT_FAILURE, "couldn't grab _SC_HOST_NAME_MAX");
     ++hostNameMax; /* for the nul terminator */
     if (hostNameMax > sizeof buf) {
-        hostBuf = ecalloc(hostNameMax, 1);
+        hostBuf = erealloc(NULL, hostNameMax);
         hostBufLen = hostNameMax;
     } else { /* optimize of the common case, when local buf would suffice */
         hostBuf = buf;

--- a/src/util.c
+++ b/src/util.c
@@ -45,3 +45,11 @@ void *ecalloc(size_t nmemb, size_t size)
         err(EXIT_FAILURE, "calloc");
     return p;
 }
+
+void *erealloc(void *ptr, size_t size)
+{
+    void *p = realloc(ptr, size);
+    if (!p)
+        err(EXIT_FAILURE, "realloc");
+    return p;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -30,3 +30,4 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 char *estrdup(const char *);
 void *ecalloc(size_t, size_t);
+void *erealloc(void *, size_t);


### PR DESCRIPTION
this dynamically allocates a buffer for hostname if the local `buf` isn't big enough.

also change the `buf` size from 20 to 256 (which is HOST_NAME_MAX + 1) for most systems.