### PR TITLE
allow `b` prefix in --delay argument

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -29,9 +29,9 @@ OPTIONS
   -C, --class NAME          NAME is a window class name. Associative with -k.
   -c, --count               Display a countdown when used with -d.
   -D, --display DISPLAY     DISPLAY is the display to use; see X(7).
-  -d, --delay SEC           Wait SEC seconds before taking a shot.
-      --delay-select        If both delay and selection is active, then
-                            perform the delay first.
+  -d, --delay [b]SEC        Wait SEC seconds before taking a shot.
+                            When given the `b` prefix, e.g `-d b8`, the delay
+                            will be applied before selection.
   -e, --exec CMD            Execute CMD on the saved image.
   -F, --file                File name. See SPECIAL STRINGS.
   -f, --freeze              Freeze the screen when -s is used.

--- a/src/options.c
+++ b/src/options.c
@@ -341,11 +341,6 @@ static const char *getPathOfStdout(void)
 void optionsParse(int argc, char *argv[])
 {
     static char stropts[] = "a:ofipbcd:e:hmq:s::t:uvzn:l:D:k::C:S:F:M:";
-    enum { /* constants for long-opt only */
-        /* ensure these cannot be represented as a single byte so that they
-         * don't collude with short-opts */
-        OPT_DELAY_SELECT = UCHAR_MAX + 1,
-    };
 
     static struct option lopts[] = {
         /* actions */
@@ -376,7 +371,6 @@ void optionsParse(int argc, char *argv[])
         { "script", required_argument, 0, 'S' },
         { "file", required_argument, 0, 'F' },
         { "monitor", required_argument, 0, 'M'},
-        { "delay-select", no_argument, 0, OPT_DELAY_SELECT},
         { 0, 0, 0, 0 }
     };
     int optch = 0;
@@ -397,6 +391,10 @@ void optionsParse(int argc, char *argv[])
             opt.border = 1;
             break;
         case 'd':
+            if (*optarg == 'b') {
+                opt.delay_selection = true;
+                ++optarg;
+            }
             opt.delay = optionsParseNum(optarg, 0, INT_MAX, &errmsg);
             if (errmsg) {
                 errx(EXIT_FAILURE, "option --delay: '%s' is %s", optarg,
@@ -474,9 +472,6 @@ void optionsParse(int argc, char *argv[])
                 errx(EXIT_FAILURE, "option --monitor: '%s' is %s", optarg,
                     errmsg);
             }
-            break;
-        case OPT_DELAY_SELECT:
-            opt.delay_selection = true;
             break;
         case '?':
             exit(EXIT_FAILURE);


### PR DESCRIPTION
the b prefix will indicate that the user wants the delay to be applied before the selection (if selection is active).

this also removes --delay-select, it was awkward to use and more lengthy than `-d b8`.