### PR TITLE
optionsNameThumbnail: fix sign integer warning

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -535,11 +535,11 @@ static void showVersion(void)
 
 static char *optionsNameThumbnail(const char *name)
 {
-    const size_t nameLength = strlen(name);
+    const ptrdiff_t nameLength = strlen(name);
     const char thumbSuffix[] = "-thumb";
     Stream ret = {0};
     const char *const extension = strrchr(name, '.');
-    const size_t baseNameLength = extension ? extension-name : nameLength;
+    const ptrdiff_t baseNameLength = extension ? extension-name : nameLength;
 
     streamMem(&ret, name, baseNameLength);
     streamMem(&ret, thumbSuffix, sizeof(thumbSuffix)-1);


### PR DESCRIPTION
fixes a warning in the ubuntu CI

	../../../src/options.c:542:47: warning: operand of ‘?:’ changes signedness from ‘long int’ to ‘size_t’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
	  542 |     const size_t baseNameLength = extension ? extension-name : nameLength;