### PR TITLE
improve timing in `scrot --delay`

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -380,8 +380,8 @@ void optionsParse(int argc, char *argv[])
             opt.display = optarg;
             break;
         case 'd':
-            opt.delay_selection = *optarg == 'b';
-            if (opt.delay_selection)
+            opt.delaySelection = *optarg == 'b';
+            if (opt.delaySelection)
                 ++optarg;
             opt.delay = optionsParseNum(optarg, 0, INT_MAX, &errmsg);
             if (errmsg) {

--- a/src/options.h
+++ b/src/options.h
@@ -38,6 +38,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
+#include <time.h>
+
 #include "scrot_selection.h"
 
 // General purpose enum
@@ -49,6 +51,7 @@ enum Direction {
 
 struct ScrotOptions {
     int delay;
+    struct timespec delayStart;
     int quality;
     enum thumb { THUMB_DISABLED, THUMB_PERCENT, THUMB_RES } thumb;
     int thumbPercent;
@@ -75,7 +78,7 @@ struct ScrotOptions {
     int autoselectW;
     SelectionMode selection;
     int monitor;
-    bool delay_selection;
+    bool delaySelection;
     bool countdown;
     bool border;
     bool silent;

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -428,8 +428,7 @@ Imlib_Image scrotSelectionSelectMode(void)
 
     opt.selection.mode = SELECTION_MODE_CAPTURE;
 
-    /* if --delay-select is active, then do the delay before selection */
-    if (opt.delay_selection)
+    if (opt.delaySelection)
         scrotDoDelay();
 
     if (!scrotSelectionGetUserSel(&rect0))
@@ -441,8 +440,10 @@ Imlib_Image scrotSelectionSelectMode(void)
         if (!scrotSelectionGetUserSel(&rect1))
             return NULL;
 
-    if (!opt.delay_selection)
+    if (!opt.delaySelection) {
+        clock_gettime(CONTINUOUS_CLOCK, &opt.delayStart);
         scrotDoDelay();
+    }
 
     Imlib_Image capture = imlib_create_image_from_drawable(0, rect0.x, rect0.y,
         rect0.w, rect0.h, 1);

--- a/src/util.h
+++ b/src/util.h
@@ -1,6 +1,6 @@
 /* util.h
 
-Copyright 2021 Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021,2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2023 NRK <nrk@disroot.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -25,6 +25,19 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 #pragma once
+
+#include <time.h>
+
+/* On Linux, CLOCK_MONOTONIC does not progress while the system is suspended,
+ * and an alternative non-standard clock which does not suffer from this problem
+ * called CLOCK_BOOTTIME is available. Scrot's CONTINUOUS_CLOCK has the exact
+ * same semantics as CLOCK_MONOTONIC, only it avoids this bug.
+ */
+#if defined(__linux__)
+    #define CONTINUOUS_CLOCK CLOCK_BOOTTIME
+#else
+    #define CONTINUOUS_CLOCK CLOCK_MONOTONIC
+#endif
 
 #define ARRAY_COUNT(X)   (sizeof(X) / sizeof(0[X]))
 #define MAX(A, B)        ((A) > (B) ? (A) : (B))


### PR DESCRIPTION
This will conflict with #257, has only been minimally tested, and there are other places in the code where it's useful but hasn't been put to use yet, so it remains a draft.

Old `nanosleep()` code (master) on OpenBSD:
![openbsd-scrot-nanosleep](https://user-images.githubusercontent.com/25590950/230230221-1765e6fa-565e-4910-a78f-facd6627e411.png)
New `clock_nanosleep()` code (this PR), falling back to a local `clock_nanosleep()` implementation on systems lacking this POSIX function like OpenBSD and OS X, running on OpenBSD: 
![openbsd-scrot-clock_nanosleep](https://user-images.githubusercontent.com/25590950/230230240-33d41d0a-636e-4e10-8f70-a20118181032.png)
The timing error is consistently smaller across several runs. If you subtract the user and system runtime and the 60 second sleep from the real runtime, you get the timing error. It has been reduced by an order of magnitude here.