### PR TITLE
fix displaying incorrect error message

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
     }
 
     if (!image)
-        err(EXIT_FAILURE, "no image grabbed");
+        errx(EXIT_FAILURE, "no image grabbed");
 
     if (opt.note)
         scrotNoteDraw(image);


### PR DESCRIPTION
the scrotGrab* functions do not necessarily set errno.

to reproduce run: `scrot -s` and then cancle the selection with keyboard press.