### PR TITLE
fix: faulty strerror call

### DIFF
--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -225,7 +225,7 @@ void scrotSelectionGetLineColor(XColor *color)
 
     if (!ret) {
         scrotSelectionDestroy();
-        errx(EXIT_FAILURE, "Error allocate color:%s", strerror(BadColor));
+        errx(EXIT_FAILURE, "Error allocating color: %s", opt.lineColor);
     }
 }
 


### PR DESCRIPTION
strerror operates on errno values, not X error codes.