### PR TITLE
style: fix some consistency issues

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -191,22 +191,18 @@ static void optionsParseSelection(const char *optarg)
     if (!strncmp(value, SELECTION_MODE_S_CAPTURE, SELECTION_MODE_L_CAPTURE)) {
         opt.selection.mode = SELECTION_MODE_CAPTURE;
         return; /* it has no parameter */
-    }
-    else if (!strncmp(value, SELECTION_MODE_S_HIDE, SELECTION_MODE_L_HIDE)) {
+    } else if (!strncmp(value, SELECTION_MODE_S_HIDE, SELECTION_MODE_L_HIDE)) {
         opt.selection.mode = SELECTION_MODE_HIDE;
         value += SELECTION_MODE_L_HIDE;
-    }
-    else if (!strncmp(value, SELECTION_MODE_S_HOLE, SELECTION_MODE_L_HOLE)) {
+    } else if (!strncmp(value, SELECTION_MODE_S_HOLE, SELECTION_MODE_L_HOLE)) {
         opt.selection.mode = SELECTION_MODE_HOLE;
-    }
-    else if (!strncmp(value, SELECTION_MODE_S_BLUR, SELECTION_MODE_L_BLUR)) {
+    } else if (!strncmp(value, SELECTION_MODE_S_BLUR, SELECTION_MODE_L_BLUR)) {
         opt.selection.mode = SELECTION_MODE_BLUR;
         opt.selection.paramNum = SELECTION_MODE_BLUR_DEFAULT;
         value += SELECTION_MODE_L_BLUR;
-    }
-    else {
+    } else {
         errx(EXIT_FAILURE, "option --select: Unknown value for suboption '%s'",
-             value);
+            value);
     }
 
     if (opt.selection.mode & SELECTION_MODE_NOT_NEED_PARAM)

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -85,8 +85,7 @@ static char *imPrintf(const char *, struct tm *, const char *, const char *,
     Imlib_Image);
 static char *scrotGetWindowName(Window);
 static Window scrotGetClientWindow(Display *, Window);
-static Window scrotFindWindowByProperty(Display *, const Window,
-                                              const Atom);
+static Window scrotFindWindowByProperty(Display *, const Window, const Atom);
 static Imlib_Image stalkImageConcat(ScrotList *, const enum Direction);
 static int findWindowManagerFrame(Window *const, int *const);
 static Imlib_Image scrotGrabWindowById(Window const window);
@@ -806,8 +805,7 @@ static Imlib_Image scrotGrabStackWindows(void)
     XImage *ximage = NULL;
     XWindowAttributes attr;
     unsigned long i = 0;
-
-#define EWMH_CLIENT_LIST "_NET_CLIENT_LIST" // spec EWMH
+    char EWMH_CLIENT_LIST[] = "_NET_CLIENT_LIST"; // spec EWMH
 
     Atom atomProp = XInternAtom(disp, EWMH_CLIENT_LIST, False);
     Atom atomType = AnyPropertyType;

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -469,7 +469,7 @@ Imlib_Image scrotSelectionSelectMode(void)
 
     imlib_context_set_image(capture);
 
-    switch(opt.selection.mode) {
+    switch (opt.selection.mode) {
     case SELECTION_MODE_HOLE:
         if (opacity > 0) {
             Imlib_Image hole = imlib_clone_image();
@@ -515,7 +515,7 @@ Imlib_Image scrotSelectionSelectMode(void)
         break;
     }
     default:
-        assert(0);
+        assert(0 && "unreachable");
     }
 
     return capture;

--- a/src/util.c
+++ b/src/util.c
@@ -33,8 +33,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 char *estrdup(const char *str)
 {
-    char *p;
-    if ((p = strdup(str)) == NULL)
+    char *p = strdup(str);
+    if (!p)
         err(EXIT_FAILURE, "strdup");
     return p;
 }


### PR DESCRIPTION
* else and else if are supposed to be on the same line as the closing brace: https://webkit.org/code-style-guidelines/#linebreaking-else-braces
* switch statement should have a space
* webkit style recommends using `!p` instead of `p == NULL`
* remove an unnecessary macro and use a local char array instead