### PR TITLE
Remove unnecessary string duplication

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -59,20 +59,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "scrot_selection.h"
 #include "util.h"
 
-#define STR_LEN_MAX_FILENAME(msg, fileName) do {                \
-    if (strlen((fileName)) > MAX_FILENAME) {                    \
-        errx(EXIT_FAILURE, #msg " filename too long, must be "  \
-            "less than %d characters", MAX_FILENAME);           \
-    }                                                           \
-} while(0)
-
-#define checkMaxInputFileName(fileName) \
-    STR_LEN_MAX_FILENAME(input, (fileName))
-
-enum {
-    MAX_FILENAME = 256, // characters
-};
-
 struct ScrotOptions opt = {
     .quality = 75,
     .lineStyle = LineSolid,
@@ -222,7 +208,6 @@ static void optionsParseSelection(const char *optarg)
         if (errmsg)
             errx(EXIT_FAILURE, "option --select: '%s' is %s", value, errmsg);
     } else { // SELECTION_MODE_HIDE
-        checkMaxInputFileName(value);
         opt.selection.fileName = value;
     }
 }

--- a/src/options.c
+++ b/src/options.c
@@ -83,6 +83,7 @@ struct ScrotOptions opt = {
     .monitor = -1,
     .windowId = None,
     .outputFile = "%Y-%m-%d-%H%M%S_$wx$h_scrot.png",
+    .lineColor = "gray",
 };
 
 static void showUsage(void);
@@ -283,7 +284,7 @@ static void optionsParseLine(char *optarg)
                     token[Color]);
             }
 
-            opt.lineColor = estrdup(value);
+            opt.lineColor = value;
             break;
         case Mode:
             if (!optionsParseIsString(value)) {

--- a/src/options.c
+++ b/src/options.c
@@ -222,10 +222,8 @@ static void optionsParseSelection(const char *optarg)
         if (errmsg)
             errx(EXIT_FAILURE, "option --select: '%s' is %s", value, errmsg);
     } else { // SELECTION_MODE_HIDE
-
         checkMaxInputFileName(value);
-
-        opt.selection.paramStr = estrdup(value);
+        opt.selection.paramStr = value;
     }
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -199,7 +199,7 @@ static void optionsParseSelection(const char *optarg)
         opt.selection.mode = SELECTION_MODE_HOLE;
     } else if (!strncmp(value, SELECTION_MODE_S_BLUR, SELECTION_MODE_L_BLUR)) {
         opt.selection.mode = SELECTION_MODE_BLUR;
-        opt.selection.paramNum = SELECTION_MODE_BLUR_DEFAULT;
+        opt.selection.blur = SELECTION_MODE_BLUR_DEFAULT;
         value += SELECTION_MODE_L_BLUR;
     } else {
         errx(EXIT_FAILURE, "option --select: Unknown value for suboption '%s'",
@@ -217,13 +217,13 @@ static void optionsParseSelection(const char *optarg)
 
     if (opt.selection.mode == SELECTION_MODE_BLUR) {
         const char *errmsg;
-        opt.selection.paramNum = optionsParseNum(value,
+        opt.selection.blur = optionsParseNum(value,
             SELECTION_MODE_BLUR_MIN, SELECTION_MODE_BLUR_MAX, &errmsg);
         if (errmsg)
             errx(EXIT_FAILURE, "option --select: '%s' is %s", value, errmsg);
     } else { // SELECTION_MODE_HIDE
         checkMaxInputFileName(value);
-        opt.selection.paramStr = value;
+        opt.selection.fileName = value;
     }
 }
 

--- a/src/options.c
+++ b/src/options.c
@@ -407,7 +407,7 @@ void optionsParse(int argc, char *argv[])
             }
             break;
         case 'e':
-            opt.exec = estrdup(optarg);
+            opt.exec = optarg;
             break;
         case 'F':
             FFlagSet = true;
@@ -456,7 +456,7 @@ void optionsParse(int argc, char *argv[])
             }
             break;
         case 'S':
-            opt.script = estrdup(optarg);
+            opt.script = optarg;
             break;
         case 's':
             optionsParseSelection(optarg);

--- a/src/options.h
+++ b/src/options.h
@@ -73,12 +73,12 @@ struct ScrotOptions {
     char *lineColor;
     const char *outputFile;
     char *thumbFile;
-    char *exec;
+    const char *exec;
     const char *display;
     char *note;
     Window windowId;
     const char *windowClassName;
-    char *script;
+    const char *script;
     int autoselect;
     int autoselectX;
     int autoselectY;

--- a/src/options.h
+++ b/src/options.h
@@ -70,7 +70,7 @@ struct ScrotOptions {
     int stack;
     enum Direction stackDirection;
     const char *format;
-    char *lineColor;
+    const char *lineColor;
     const char *outputFile;
     char *thumbFile;
     const char *exec;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -676,11 +676,9 @@ static char *imPrintf(const char *str, struct tm *tm, const char *filenameIM,
                 streamChar(&ret, '$');
                 break;
             case 'W':
-                if (clientWindow) {
-                    if (!(tmp = scrotGetWindowName(clientWindow)))
-                        break;
+                if (clientWindow && (tmp = scrotGetWindowName(clientWindow))) {
                     streamStr(&ret, tmp);
-                    free(tmp);
+                    XFree(tmp);
                 }
                 break;
             default:
@@ -706,6 +704,7 @@ static char *imPrintf(const char *str, struct tm *tm, const char *filenameIM,
     return ret.buf;
 }
 
+/* return value should be freed by XFree() */
 static char *scrotGetWindowName(Window window)
 {
     assert(disp != NULL);
@@ -725,9 +724,8 @@ static char *scrotGetWindowName(Window window)
             &clsHint);
 
     if (status != 0) {
-        windowName = estrdup(clsHint.res_class);
+        windowName = clsHint.res_class;
         XFree(clsHint.res_name);
-        XFree(clsHint.res_class);
     }
     return windowName;
 }

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -474,7 +474,7 @@ Imlib_Image scrotSelectionSelectMode(void)
         break;
     case SELECTION_MODE_HIDE:
     {
-        const char *const fileName = opt.selection.paramStr;
+        const char *const fileName = opt.selection.fileName;
 
         if (fileName) {
             if (opacity > 0) {
@@ -495,7 +495,7 @@ Imlib_Image scrotSelectionSelectMode(void)
     }
     case SELECTION_MODE_BLUR:
     {
-        const int amountBlur = opt.selection.paramNum;
+        const int amountBlur = opt.selection.blur;
         Imlib_Image blur = imlib_clone_image();
         imlib_context_set_image(blur);
         imlib_image_blur(amountBlur);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -219,20 +219,12 @@ Status scrotSelectionCreateNamedColor(const char *nameColor, XColor *color)
 
 void scrotSelectionGetLineColor(XColor *color)
 {
-    scrotSelectionSetDefaultColorLine();
-
     const Status ret = scrotSelectionCreateNamedColor(opt.lineColor, color);
 
     if (!ret) {
         scrotSelectionDestroy();
         errx(EXIT_FAILURE, "Error allocating color: %s", opt.lineColor);
     }
-}
-
-void scrotSelectionSetDefaultColorLine(void)
-{
-    if (!opt.lineColor)
-        opt.lineColor = "gray";
 }
 
 bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -474,7 +474,7 @@ Imlib_Image scrotSelectionSelectMode(void)
         break;
     case SELECTION_MODE_HIDE:
     {
-        char *const fileName = opt.selection.paramStr;
+        const char *const fileName = opt.selection.paramStr;
 
         if (fileName) {
             if (opacity > 0) {
@@ -487,7 +487,6 @@ Imlib_Image scrotSelectionSelectMode(void)
                 imlib_context_set_image(hide);
                 imlib_free_image_and_decache();
             }
-            free(fileName);
         } else {
             imlib_context_set_color(color.red, color.green, color.blue, opacity);
             imlib_image_fill_rectangle(x, y, rect1.w, rect1.h);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -78,7 +78,7 @@ struct SelectionRect {
 typedef struct SelectionMode {
     unsigned int mode;
     int paramNum;
-    char *paramStr;
+    const char *paramStr;
 } SelectionMode;
 
 struct SelectionClassic;

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -77,8 +77,8 @@ struct SelectionRect {
 
 typedef struct SelectionMode {
     unsigned int mode;
-    int paramNum;
-    const char *paramStr;
+    int blur;
+    const char *fileName;
 } SelectionMode;
 
 struct SelectionClassic;


### PR DESCRIPTION
There are many cases in scrot where strings are unnecessarily duplicated. The goal of this patchset is to remove these.

Most of these strings also were never free-ed, so this also technically fixes some memory leaks (although in practice this isn't that big of an issue since scrot is a "one shot" program, not a long running process).

- - -

A couple other cases worth investigating:

```console
src/note.c:287:    return strndup(begin, length);
src/options.c:617:    opt.note = estrdup(optarg);
```

Also note: `opt.lineMode` is handled in #282.