### PR TITLE
scrotExecApp cleanup

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -575,7 +575,7 @@ static void scrotExecApp(Imlib_Image image, struct tm *tm, char *filenameIM,
 
     if (ret == -1)
         warn("The child process could not be created");
-    else if (WEXITSTATUS(ret) == 127)
+    else if (WIFEXITED(ret) && WEXITSTATUS(ret) == 127)
         warnx("scrot could not execute the command: %s", execStr);
     free(execStr);
 }

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -570,21 +570,14 @@ static Imlib_Image scrotGrabShot(void)
 static void scrotExecApp(Imlib_Image image, struct tm *tm, char *filenameIM,
     char *filenameThumb)
 {
-    char *execStr;
-    int ret;
-
-    execStr = imPrintf(opt.exec, tm, filenameIM, filenameThumb, image);
-
-    errno = 0;
-
-    ret = system(execStr);
+    char *execStr = imPrintf(opt.exec, tm, filenameIM, filenameThumb, image);
+    int ret = system(execStr);
 
     if (ret == -1)
         warn("The child process could not be created");
     else if (WEXITSTATUS(ret) == 127)
         warnx("scrot could not execute the command: %s", execStr);
-
-    exit(0);
+    free(execStr);
 }
 
 static Bool scrotXEventVisibility(Display *dpy, XEvent *ev, XPointer arg)


### PR DESCRIPTION
### scrotExecApp: fix memory leak and style cleanup

* execStr is allocated via imPrintf, so free it before returning.
* remove unnecessary `exit(0)` - simply let the control return back to
  `main()` where it will do some cleanup and exit anyways.
* remove useless `errno = 0`.
* initialize execStr and ret immediately.

### scrotExecApp: check for WIFEXITED first

according to waitpid(3) manpage:

| This macro (WEXITSTATUS) should be employed only if WIFEXITED returned true.
