### PR TITLE
fix: reset delay_selection properly

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -380,10 +380,9 @@ void optionsParse(int argc, char *argv[])
             opt.display = optarg;
             break;
         case 'd':
-            if (*optarg == 'b') {
-                opt.delay_selection = true;
+            opt.delay_selection = *optarg == 'b';
+            if (opt.delay_selection)
                 ++optarg;
-            }
             opt.delay = optionsParseNum(optarg, 0, INT_MAX, &errmsg);
             if (errmsg) {
                 errx(EXIT_FAILURE, "option --delay: '%s' is %s", optarg,


### PR DESCRIPTION
the convention is for newer cli arg to overwrite the older one. however as of now, opt.delay_selection doesn't properly get cleared. to reproduce:

	./scrot -d b3 -d 5 -s -c

the earlier `-d b3` makes it so that opt.delay_selection stays true even though the later `-d 5` should've overwritten it.