### PR TITLE
fix: incorrect line opacity mapping

### DIFF
--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -76,7 +76,7 @@ void selectionEdgeCreate(void)
         HeightOfScreen(scr), 0, CopyFromParent, InputOutput, CopyFromParent,
         CWOverrideRedirect | CWBackPixel, &attr);
 
-    unsigned long opacity = opt.lineOpacity * ((unsigned)-1 / 100);
+    unsigned long opacity = opt.lineOpacity * (0xFFFFFFFFu / 255);
 
     XChangeProperty(disp, pe->wndDraw,
         XInternAtom(disp, "_NET_WM_WINDOW_OPACITY", False), XA_CARDINAL, 32,


### PR DESCRIPTION
current code treats opacity as [0, 100] even though the manpage documents it as being [0, 255].

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/281