### PR TITLE
don't get the remainder if nanosleep is interrupted

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -329,7 +329,7 @@ static void scrotWaitUntil(const struct timespec *time)
             tmp.tv_sec--;
             tmp.tv_nsec += 1000000000L;
         }
-    } while (nanosleep(&tmp, &tmp) == -1 && errno == EINTR);
+    } while (nanosleep(&tmp, NULL) == -1 && errno == EINTR);
 }
 
 /* Clip rectangle nicely */


### PR DESCRIPTION
Fallout from https://github.com/resurrecting-open-source-projects/scrot/pull/261