### PR TITLE
remove some useless assert()s

### DIFF
--- a/src/note.c
+++ b/src/note.c
@@ -237,7 +237,6 @@ void scrotNoteDraw(Imlib_Image im)
     if (!im)
         return;
 
-    assert(note);
     assert(note->imFont);
 
     imlib_context_set_image(im);
@@ -256,8 +255,6 @@ void scrotNoteDraw(Imlib_Image im)
 
 static void loadFont(void)
 {
-    assert(note);
-
     note->imFont = imlib_load_font(note->font);
 
     if (!note->imFont)
@@ -266,9 +263,6 @@ static void loadFont(void)
 
 static char *parseText(char **token, char const *const end)
 {
-    assert(NULL != *token);
-    assert(NULL != end);
-
     if (**token != '\'')
         return NULL;
 

--- a/src/options.c
+++ b/src/options.c
@@ -41,7 +41,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-#include <assert.h>
 #include <err.h>
 #include <errno.h>
 #include <getopt.h>

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -719,7 +719,6 @@ static char *imPrintf(const char *str, struct tm *tm, const char *filenameIM,
 static char *scrotGetWindowName(Window window)
 {
     assert(disp != NULL);
-    assert(window != None);
 
     if (window == root)
         return NULL;

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -77,8 +77,6 @@ static void createCursors(void)
 {
     struct Selection *const sel = *selectionGet();
 
-    assert(sel != NULL);
-
     if (opt.selection.mode == SELECTION_MODE_CAPTURE)
         sel->curCross = XCreateFontCursor(disp, XC_cross);
     else if (opt.selection.mode == SELECTION_MODE_HIDE)
@@ -96,8 +94,6 @@ static void createCursors(void)
 static void freeCursors(void)
 {
     struct Selection *const sel = *selectionGet();
-
-    assert(sel != NULL);
 
     XFreeCursor(disp, sel->curCross);
     XFreeCursor(disp, sel->curAngleNE);
@@ -137,8 +133,6 @@ void scrotSelectionCreate(void)
     selectionAllocate();
 
     struct Selection *const sel = *selectionGet();
-
-    assert(sel != NULL);
 
     createCursors();
 

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -1,7 +1,7 @@
 /* scrot_selection_classic.c
 
 Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
-Copyright 2021-2022 Guilherme Janczak <guilherme.janczak@yandex.com>
+Copyright 2021-2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 Copyright 2021      Peter Wu <peterwu@hotmail.com>
 Copyright 2023      NRK <nrk@disroot.org>
 
@@ -31,7 +31,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     Part of the code comes from the scrot.c file and maintains its authorship.
 */
 
-#include <assert.h>
 #include <stdlib.h>
 #include <err.h>
 


### PR DESCRIPTION
All of the removed assert()s are checking whether pointers that are soon to be dereferenced by scrot are NULL. There are many more pointers in the source code that don't get assert()ed and any OS these days will have NULL == 0 and an unmapped 0-page that causes the program to segfault on read/write, the exception would be MMU-less systems, but we don't expect people to develop on those.

The only exception is scrotGetWindowName(), but the assert() redundantly checks if the function's argument is NULL, when its only caller already does that without assert().