### PR TITLE
deprecate --display

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -2,8 +2,8 @@ NAME
   scrot - command line screen capture utility
 
 SYNOPSIS
-  scrot [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY] [-d SEC] [-e CMD]
-        [-k OPT] [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-s OPTS] [-t % | WxH]
+  scrot [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-d SEC] [-e CMD] [-k OPT]
+        [-l STYLE] [-M NUM] [-n OPTS] [-q NUM] [-s OPTS] [-t % | WxH]
         [-w NUM] [[-F] FILE]
 
 DESCRIPTION
@@ -28,7 +28,6 @@ OPTIONS
                             Use with -s to raise the focus of the window.
   -C, --class NAME          NAME is a window class name. Associative with -k.
   -c, --count               Display a countdown when used with -d.
-  -D, --display DISPLAY     DISPLAY is the display to use; see X(7).
   -d, --delay [b]SEC        Wait SEC seconds before taking a shot.
                             When given the `b` prefix, e.g `-d b8`, the delay
                             will be applied before selection.

--- a/src/options.c
+++ b/src/options.c
@@ -501,8 +501,8 @@ void optionsParse(int argc, char *argv[])
 static void showUsage(void)
 {
     fputs(/* Check that everything lines up after any changes. */
-        "usage:  " PACKAGE " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]\n"
-        "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM] [-n OPTS]\n"
+        "usage:  " PACKAGE " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-d SEC]\n"
+        "              [-e CMD] [-k OPT] [-l STYLE] [-M NUM] [-n OPTS]\n"
         "              [-q NUM] [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
         stdout);
     exit(0);

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -110,6 +110,10 @@ int main(int argc, char *argv[])
 
     optionsParse(argc, argv);
 
+    if (opt.display) {
+        warnx("--display is deprecated.");
+        warnx("Specify an X server through the DISPLAY environment variable");
+    }
     initXAndImlib(opt.display, 0);
 
     if (opt.selection.mode & SELECTION_MODE_ANY)


### PR DESCRIPTION
We don't need to duplicate the work XOpenDisplay() already does for us. Mark --display for removal at a later date.

![2023-05-20-192641_678x87_scrot](https://github.com/resurrecting-open-source-projects/scrot/assets/25590950/1cc78e5d-3195-49a8-b822-58b0522cfd0c)
