### PR TITLE
remove undocumented --focussed spelling of --focused

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -350,8 +350,6 @@ void optionsParse(int argc, char *argv[])
         {"select",          optional_argument,  NULL,   's'},
         {"thumb",           required_argument,  NULL,   't'},
         {"focused",         no_argument,        NULL,   'u'},
-        /* macquarie dictionary has both spellings */
-        {"focussed",        no_argument,        NULL,   'u'},
         {"version",         no_argument,        NULL,   'v'},
         {"window",          required_argument,  NULL,   'w'},
         {"compression",     required_argument,  NULL,   'Z'},


### PR DESCRIPTION
Fixes a small part of #272.
Wikitionary says "focused" is the common spelling in the Commonwealth and the US: https://en.wiktionary.org/wiki/focussed although "focussed" is recognized as valid.