### PR TITLE
selectionEdgeDestroy: misc cleanups

### DIFF
--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -131,10 +131,13 @@ void selectionEdgeDestroy(void)
     if (pe->wndDraw != None) {
         XSelectInput(disp, pe->wndDraw, StructureNotifyMask);
         XDestroyWindow(disp, pe->wndDraw);
-        for (XEvent ev; true;) {
+        bool is_unmapped = false, is_destroyed = false;
+        for (XEvent ev; !(is_unmapped && is_destroyed);) {
             XNextEvent(disp, &ev);
             if (ev.type == DestroyNotify && ev.xdestroywindow.window == pe->wndDraw)
-                break;
+                is_destroyed = true;
+            if (ev.type == UnmapNotify && ev.xunmap.window == pe->wndDraw)
+                is_unmapped = true;
         }
         /* HACK: although we recived a DestroyNotify event, the frame still
          * might not have been updated. a compositor might also buffer frames

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -31,6 +31,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     Part of the code comes from the scrot.c file and maintains its authorship.
 */
 
+#include <errno.h>
 #include <stdlib.h>
 #include <time.h>
 
@@ -135,6 +136,12 @@ void selectionEdgeDestroy(void)
             if (ev.type == DestroyNotify && ev.xdestroywindow.window == pe->wndDraw)
                 break;
         }
+        /* HACK: although we recived a DestroyNotify event, the frame still
+         * might not have been updated. a compositor might also buffer frames
+         * adding latency. so wait a bit for the screen to update and the
+         * selection borders to go away. */
+        struct timespec t = { .tv_nsec = 80 * 1000L * 1000L };
+        while (nanosleep(&t, &t) < 0 && errno == EINTR);
 
         XFree(pe->classHint);
     }


### PR DESCRIPTION
* xeventUnmap() did not check the union type before reading from it.
* unmap event should always come, no need to sleep/retry 30 times.
* remove xeventUnmap() and waitUnmapWindowNotify() entirely. the main logic is short enough to inline directly at the call site.
* rather than unmapping the window, and then destroying it, destroy it directly and wait for the DestroyNotify event. (this may help with: https://github.com/resurrecting-open-source-projects/scrot/issues/284)
* compare window ID against `None` rather than `0`. no functional difference, but using `None` is more idiomatic for X11 things.