### PR TITLE
fix: build on c99 or -std=c99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,8 @@ AS_IF([test "x$orig_CFLAGS" = "x"], [
     AX_APPEND_LINK_FLAGS(["$SCROT_FLAGS"])
 ])
 
+AX_APPEND_COMPILE_FLAGS("-D_XOPEN_SOURCE=700L")
+
 # Checks for libraries.
 PKG_CHECK_MODULES([X11], [x11])
 PKG_CHECK_MODULES([XCOMPOSITE], [xcomposite])


### PR DESCRIPTION
currently scrot fails to build when either CC=c99 or CFLAGS contains -std=c99 because they disable _GNU_SOURCE feature-test-macro. to reproduce:

	./autogen.sh && ./configure CC=c99 && make

or

	./autogen.sh && ./configure CFLAGS="-std=c99" && make

we do not use any gnu c language extension, as such we should build fine under c99 or -std=c99

fix the build via appending `-D_XOPEN_SOURCE=700L` to the compile flags. which is equivalent to `_POSIX_C_SOURCE=200809L` except that it also unlocks the X/Open System Interfaces.

ref: https://man7.org/linux/man-pages/man7/feature_test_macros.7.html