### PR TITLE
README: pkg-config is abandoned, recommend pkgconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ scrot requires a few projects and libraries:
 
 - [autoconf](https://www.gnu.org/software/autoconf/autoconf.html) (build time only)
 - [autoconf-archive](https://www.gnu.org/software/autoconf-archive/) (build time only)
-- [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) (build time only)
+- A pkg-config implementation [(e.g. pkgconf)](https://github.com/pkgconf/pkgconf) (build time only)
 - [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
 - [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --enable-libbsd-feature-test` returns true)
-- X [(e.g. X.Org)](https://www.x.org/wiki/)
+- An X11 implementation [(e.g. X.Org)](https://www.x.org/wiki/)
 - libXcomposite [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxcomposite)
 - libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)
 - libXfixes [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxfixes)


### PR DESCRIPTION
The last release of pkg-config was in 2017-03-20:
https://pkgconfig.freedesktop.org/releases/

pkgconf has silently replaced pkg-config in the wild. For instance, in Debian: https://packages.debian.org/sid/pkg-config

Let's recommend the maintained implementation.