### PR TITLE
fix: license name in README and manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ scrot has many useful features:
 Because scrot is a command line utility, it can easily be scripted and put to
 novel uses. For instance, scrot can be used to monitor an X server in absence.
 
-scrot is free software under the [MIT-advertising](COPYING) license.
+scrot is free software under the [MIT-feh](COPYING) license.
 
 ## Help this project ##
 

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -19,7 +19,7 @@ DESCRIPTION
   Because scrot is a command line utility, it can easily be scripted and put to
   novel uses. For instance, scrot can be used to monitor an X server in absence.
 
-  scrot is free software under the MIT-advertising license.
+  scrot is free software under the MIT-feh license.
 
 OPTIONS
   -a, --autoselect X,Y,W,H  Non-interactively choose a rectangle starting at


### PR DESCRIPTION
scrot's license has always been (as far as the git history goes at least) MIT-feh [0]. but the README and manpage incorrectly identified it as MIT-advertising [1].

so change it to MIT-feh. (note: the content of the license is still same, this is just fixing a misidentification.)

[0]: https://spdx.org/licenses/MIT-feh.html
[1]: https://spdx.org/licenses/MIT-advertising.html

Closes: https://github.com/resurrecting-open-source-projects/scrot/issues/310