### PR TITLE
scrotGrabMousePointer: error out on failure

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -448,12 +448,9 @@ Window scrotGetWindow(Display *display, Window window, int x, int y)
 void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     const int yOffset)
 {
-    XFixesCursorImage *xcim = NULL;
-    /* Get the X cursor and the information we want. */
-    if ((xcim = XFixesGetCursorImage(disp)) == NULL) {
-        warnx("Can't get the cursor from X");
-        goto end;
-    }
+    XFixesCursorImage *xcim = XFixesGetCursorImage(disp);
+    if (!xcim)
+        errx(EXIT_FAILURE, "Can't get the cursor from X");
     const unsigned short width = xcim->width;
     const unsigned short height = xcim->height;
     const size_t pixcnt = (size_t)width*height;
@@ -467,10 +464,8 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     }
 
     Imlib_Image imcursor = imlib_create_image_using_data(width, height, pixels);
-    if (!imcursor) {
-        warnx("Can't create cursor image");
-        goto end;
-    }
+    if (!imcursor)
+        errx(EXIT_FAILURE, "Can't create cursor image");
 
     /* Overlay the cursor into `image`. */
     const int x = (xcim->x - xcim->xhot) - xOffset;
@@ -482,8 +477,6 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
         height);
     imlib_context_set_image(imcursor);
     imlib_free_image();
-
-end:
     XFree(xcim);
 }
 

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -449,7 +449,6 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     const int yOffset)
 {
     XFixesCursorImage *xcim = NULL;
-    uint32_t *pixels = NULL;
     /* Get the X cursor and the information we want. */
     if ((xcim = XFixesGetCursorImage(disp)) == NULL) {
         warnx("Can't get the cursor from X");
@@ -459,16 +458,13 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     const unsigned short height = xcim->height;
     const size_t pixcnt = (size_t)width*height;
 
-    /* xcim->pixels wouldn't be valid if sizeof(*pixels)*pixcnt wrapped around.
-     */
-    if ((pixels = malloc(sizeof(*pixels)*pixcnt)) == NULL) {
-        warn("malloc()");
-        goto end;
-    }
+    uint32_t *pixels = (uint32_t *)xcim->pixels;
     /* XFixesCursorImage returns pixels as `unsigned long`, which is typically
      * 64bits, but imlib2 expects 32bit packed integers. */
-    for (size_t i = 0; i < pixcnt; i++)
-        pixels[i] = xcim->pixels[i];
+    if (sizeof *xcim->pixels > sizeof *pixels) {
+        for (size_t i = 0; i < pixcnt; ++i)
+            pixels[i] = xcim->pixels[i];
+    }
 
     Imlib_Image imcursor = imlib_create_image_using_data(width, height, pixels);
     if (!imcursor) {
@@ -488,7 +484,6 @@ void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
     imlib_free_image();
 
 end:
-    free(pixels);
     XFree(xcim);
 }
 


### PR DESCRIPTION
This turns the previous warnings into errors instead - since we couldn't accomplish what the user asked us to.

And while working on this, I also realized that the in-place mutation wouldn't violate strict aliasing and is legal. So remove the failure point created by `malloc` entirely.

ref: https://github.com/resurrecting-open-source-projects/scrot/issues/272