### PR TITLE
ci: add cppcheck for static analysis

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -34,8 +34,9 @@ jobs:
     - name: cppcheck
       run: |
         cppcheck --version
-        cppcheck -j$(nproc) --enable=portability,performance --quiet --force \
-            --error-exitcode=1 src/*.c $(pkg-config --cflags ./deps.pc)
+        cppcheck --std=c99 -j$(nproc) --quiet --force --error-exitcode=1 \
+            --enable=portability,performance src/*.c \
+            $(pkg-config --cflags ./deps.pc)
   cygwin:
     runs-on: windows-latest
     env:

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -16,7 +16,7 @@ jobs:
     - name: install_dependencies
       run: |
         sudo apt install libimlib2-dev libxcomposite-dev libxfixes-dev \
-             autoconf-archive libbsd-dev libxinerama-dev
+             autoconf-archive libbsd-dev libxinerama-dev cppcheck
     - name: distcheck
       run: |
         ./autogen.sh
@@ -31,6 +31,11 @@ jobs:
         make -s distclean
         c99 -o src/scrot src/*.c $(pkg-config --cflags --libs ./deps.pc)
         src/scrot -v
+    - name: cppcheck
+      run: |
+        cppcheck --version
+        cppcheck -j$(nproc) --enable=portability,performance --quiet --force \
+            --error-exitcode=1 src/*.c $(pkg-config --cflags ./deps.pc)
   cygwin:
     runs-on: windows-latest
     env:


### PR DESCRIPTION
cppcheck is a decent static analyzer that can catch some interesting issues that compiler warnings (and sometimes even other analyzers) don't catch.

currently cppcheck doesn't find anything, but that's because I had mostly fixed it's finding very early on when I started contributing to scrot.

I've had cppcheck, along with gcc -fanalyzer and clang-tidy running locally for quite some time now. it will be worthwhile to add it to the CI so that it's findings can be visible to other contributors as well.

in the future, we might want to enable `-fanalyzer` and clang-tidy as well, but clang-tidy currently produces 3 warnings, 2 of which I've investigated and found to be false-positives (haven't investigated the 3rd one).

to run clang-tidy locally:

	$ clang-tidy --quiet --checks="-clang-analyzer-security.insecureAPI.*" \
	       src/*.c -- -Wall -Wextra -Wpedantic -DDEBUG \
	       $(pkg-config --cflags ./deps.pc)

(note, I've disabled the "insecureAPI" check because it is garbage. it flags every `memcpy` call as "insecure" and tells you to use the nonportable `memcpy_s` instead.)

gcc -fanalyzer is relatively new and not as mature as cppcheck or clang-tidy but it's getting better each version. currently it spits out a bunch of warnings, I haven't investigated them too thoroughly but they seem like false-positives.

to run gcc -fanalyzer locally:

	$ gcc -o /dev/null src/*.c -std=c99 -Wall -Wextra -Wpedantic \
	      -O3 -flto -fanalyzer $(pkg-config --cflags --libs ./deps.pc)

note: both gcc/clang-tidy accepts `-Werror`, which we probably want to enable if we put it in the CI.