### PR TITLE
Revise scrotWaitUntil interface

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -390,7 +390,8 @@ void optionsParse(int argc, char *argv[])
             opt.delaySelection = *optarg == 'b';
             if (opt.delaySelection)
                 ++optarg;
-            opt.delay = optionsParseNum(optarg, 0, INT_MAX, &errmsg);
+            /* NOTE: div 1000 so that converting to milliseconds doesn't overflow */
+            opt.delay = optionsParseNum(optarg, 0, INT_MAX/1000, &errmsg);
             if (errmsg) {
                 errx(EXIT_FAILURE, "option --delay: '%s' is %s", optarg,
                     errmsg);

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -74,6 +74,7 @@ static size_t scrotHaveFileExtension(const char *, char **);
 static Imlib_Image scrotGrabFocused(void);
 static void applyFilterIfRequired(void);
 static Imlib_Image scrotGrabAutoselect(void);
+static long miliToNanoSec(int);
 static void scrotWaitUntil(const struct timespec *);
 static Imlib_Image scrotGrabShotMulti(void);
 static Imlib_Image scrotGrabShotMonitor(void);
@@ -145,7 +146,7 @@ int main(int argc, char *argv[])
      * screenshot-taking above or it will skew the timing.
      */
     clock_gettime(CLOCK_REALTIME, &timeStamp);
-    if (timeStamp.tv_nsec >= 500*1000*1000) {
+    if (timeStamp.tv_nsec >= miliToNanoSec(500)) {
         /* Round the timestamp to the nearest second. */
         timeStamp.tv_sec++;
     }
@@ -345,6 +346,11 @@ void scrotDoDelay(void)
     }
 }
 
+static long miliToNanoSec(int ms)
+{
+    return ms * 1000L * 1000L;
+}
+
 /* scrotWaitUntil: clock_nanosleep with a simpler interface and no EINTR nagging
  */
 static void scrotWaitUntil(const struct timespec *time)
@@ -364,7 +370,7 @@ static void scrotWaitUntil(const struct timespec *time)
         tmp.tv_nsec = time->tv_nsec - tmp.tv_nsec;
         if (tmp.tv_nsec < 0) {
             tmp.tv_sec--;
-            tmp.tv_nsec += 1000000000L;
+            tmp.tv_nsec += miliToNanoSec(1000);
         }
     } while (nanosleep(&tmp, NULL) == -1 && errno == EINTR);
 }

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -28,6 +28,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
+#include <time.h>
+
 #include <X11/Xlib.h>
 #include <Imlib2.h>
 
@@ -39,5 +41,6 @@ extern Screen *scr;
 Window scrotGetWindow(Display *, Window, int, int);
 int scrotGetGeometry(Window, int *, int *, int *, int *);
 void scrotNiceClip(int *, int *, int *, int *);
+struct timespec clockNow(void);
 void scrotDoDelay(void);
 void scrotGrabMousePointer(const Imlib_Image, const int, const int);

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -42,5 +42,6 @@ Window scrotGetWindow(Display *, Window, int, int);
 int scrotGetGeometry(Window, int *, int *, int *, int *);
 void scrotNiceClip(int *, int *, int *, int *);
 struct timespec clockNow(void);
+struct timespec scrotSleepFor(struct timespec, int);
 void scrotDoDelay(void);
 void scrotGrabMousePointer(const Imlib_Image, const int, const int);

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -233,9 +233,9 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
     ret = XGrabKeyboard(disp, root, False, GrabModeAsync, GrabModeAsync, CurrentTime);
     if (ret == AlreadyGrabbed) {
         int attempts = 20;
-        struct timespec delay = { 0, 50 * 1000L * 1000L };
+        struct timespec t = clockNow();
         do {
-            nanosleep(&delay, NULL);
+            t = scrotSleepFor(t, 50);
             ret = XGrabKeyboard(disp, root, False, GrabModeAsync, GrabModeAsync, CurrentTime);
         } while (--attempts > 0 && ret == AlreadyGrabbed);
     }

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -433,7 +433,7 @@ Imlib_Image scrotSelectionSelectMode(void)
             return NULL;
 
     if (!opt.delaySelection) {
-        clock_gettime(CONTINUOUS_CLOCK, &opt.delayStart);
+        opt.delayStart = clockNow();
         scrotDoDelay();
     }
 

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -143,8 +143,7 @@ void selectionEdgeDestroy(void)
          * might not have been updated. a compositor might also buffer frames
          * adding latency. so wait a bit for the screen to update and the
          * selection borders to go away. */
-        struct timespec t = { .tv_nsec = 80 * 1000L * 1000L };
-        while (nanosleep(&t, &t) < 0 && errno == EINTR);
+        scrotSleepFor(clockNow(), 80);
 
         XFree(pe->classHint);
     }

--- a/src/util.h
+++ b/src/util.h
@@ -26,20 +26,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
-#include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-/* On Linux, CLOCK_MONOTONIC does not progress while the system is suspended,
- * and an alternative non-standard clock which does not suffer from this problem
- * called CLOCK_BOOTTIME is available. Scrot's CONTINUOUS_CLOCK has the exact
- * same semantics as CLOCK_MONOTONIC, only it avoids this bug.
- */
-#if defined(__linux__)
-    #define CONTINUOUS_CLOCK CLOCK_BOOTTIME
-#else
-    #define CONTINUOUS_CLOCK CLOCK_MONOTONIC
-#endif
 
 #ifdef DEBUG
     #define scrotAssert(X) do { \


### PR DESCRIPTION
The `timespec` argument for nanosleep is awkward because it uses `ns` when we want to sleep for some `ms` instead. And `scrotWaitUntil` is awkward because it uses absolute time, instead of relative time.

Add `scrotWaitFor` which uses a relative time in `ms` and uses `scrotWaitUntil` internally.

CC: @guijan 