### PR TITLE
ci: add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,35 @@
+# Cannot inline comments, so here's some rationale for disabling certain checks:
+#
+# -clang-analyzer-security.insecureAPI.*:
+#    garbage check, blindly recommends using non-portable annex K functions.
+#    doesn't catch actual bugs.
+# -misc-no-recursion
+#    blindly flags every single recursion regardless of whether the usage was
+#    safe or not.
+Checks: >
+    performance-*,
+    misc-*,
+    android-cloexec-*,
+    readability-duplicate-include,
+    readability-misleading-indentation,
+    bugprone-assert-side-effect,
+    bugprone-macro-repeated-side-effects,
+    bugprone-infinite-loop,
+    bugprone-macro-parentheses,
+    bugprone-posix-return,
+    bugprone-reserved-identifier,
+    bugprone-signal-handler,
+    bugprone-signed-char-misuse,
+    bugprone-sizeof-expression,
+    bugprone-branch-clone,
+    -clang-analyzer-security.insecureAPI.*,
+    -misc-no-recursion,
+
+# treat all warnings as errors
+WarningsAsErrors: '*'
+
+CheckOptions:
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           'scrotAssert'
+
+ExtraArgs: [-std=c99,-DDEBUG]

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -37,6 +37,11 @@ jobs:
         cppcheck --std=c99 -j$(nproc) --quiet --force --error-exitcode=1 \
             --enable=portability,performance src/*.c \
             $(pkg-config --cflags ./deps.pc)
+    - name: clang-tidy
+      run: |
+        clang-tidy --version
+        find src -name '*.c' -print | xargs -P$(nproc) -I{} \
+            clang-tidy --quiet {} -- $(pkg-config --cflags ./deps.pc)
   cygwin:
     runs-on: windows-latest
     env:

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -477,7 +477,7 @@ Window scrotGetWindow(Display *display, Window window, int x, int y)
     return target;
 }
 
-void scrotGrabMousePointer(const Imlib_Image image, const int xOffset,
+void scrotGrabMousePointer(Imlib_Image image, const int xOffset,
     const int yOffset)
 {
     XFixesCursorImage *xcim = NULL;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -942,6 +942,7 @@ static Imlib_Image scrotGrabShotMonitor(void)
     if (opt.monitor >= numScreens)
         errx(EXIT_FAILURE, "monitor %d not found", opt.monitor);
 
+    scrotAssert(screens); /* silence clang-tidy */
     XineramaScreenInfo *mon = &screens[opt.monitor];
 
     /* Hack: pretend we were invoked in autoselect mode */

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -92,6 +92,7 @@ static void createCursors(void)
 static void freeCursors(void)
 {
     struct Selection *const sel = *selectionGet();
+    scrotAssert(sel); /* silence clang-tidy */
 
     XFreeCursor(disp, sel->curCross);
     XFreeCursor(disp, sel->curAngleNE);
@@ -449,7 +450,7 @@ Imlib_Image scrotSelectionSelectMode(void)
     XColor color;
     scrotSelectionGetLineColor(&color);
 
-    const int x = rect1.x - rect0.x;
+    const int x = rect1.x - rect0.x; /* NOLINT(*UndefinedBinaryOperatorResult) */
     const int y = rect1.y - rect0.y;
     const int opacity = opt.lineOpacity;
 


### PR DESCRIPTION
the list of checks as of now is fairly conservative.

one other check that might be worth enabling in the future:

* bugprone-narrowing-conversions: unfortunately it doesn't understand
  the semantics of optionsParseNum() and thus produces way too much
  noise.