### PR TITLE
deprecate --note

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -48,8 +48,6 @@ OPTIONS
                             option is used; see SELECTION STYLE.
   -M, --monitor NUM         Capture Xinerama monitor number NUM.
   -m, --multidisp           For multiple heads, screenshot all of them in order.
-  -n, --note OPTS           OPTS is a collection of options which specify notes
-                            to bake into the image. See NOTE FORMAT.
   -o, --overwrite           By default scrot does not overwrite the output
                             FILE, use this option to enable it.
   -p, --pointer             Capture the mouse pointer.
@@ -175,21 +173,6 @@ SELECTION STYLE
   Example:
 
     $ scrot -l style=dash,width=3,color="red" -s
-
-NOTE FORMAT
-  The -n option's argument is more arguments:
-
-    -f  'FontName/size'
-    -t  'text'
-    -x  position (optional)
-    -y  position (optional)
-    -c  color(RGBA, within [0, 255]) (optional)
-    -a  angle (optional)
-
-  Example:
-
-    $ scrot -n "-f '/usr/share/fonts/TTF/DroidSans-Bold/40' -x 10
-            -y 20 -c 255,0,0,255 -t 'Hi'"
 
 COMPRESSION QUALITY
 

--- a/src/options.c
+++ b/src/options.c
@@ -506,6 +506,8 @@ void optionsParse(int argc, char *argv[])
         opt.thumbFile = optionsNameThumbnail(opt.outputFile);
 
     if (note) {
+        warnx("--note is deprecated. See: "
+            "https://github.com/resurrecting-open-source-projects/scrot/discussions/207");
         opt.note = estrdup(note); /* TODO: investigate if dup is needed */
         scrotNoteNew(opt.note);
     }
@@ -515,7 +517,7 @@ static void showUsage(void)
 {
     fputs(/* Check that everything lines up after any changes. */
         "usage:  " PACKAGE_NAME " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]\n"
-        "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM] [-n OPTS]\n"
+        "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM]\n"
         "              [-q NUM] [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
         stdout);
     exit(0);

--- a/src/options.c
+++ b/src/options.c
@@ -515,10 +515,10 @@ void optionsParse(int argc, char *argv[])
 
 static void showUsage(void)
 {
-    fputs(/* Check that everything lines up after any changes. */
-        "usage:  " PACKAGE_NAME " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]\n"
-        "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM]\n"
-        "              [-q NUM] [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
+    fputs("usage:  " /* Check that everything lines up after any changes. */
+        PACKAGE_NAME " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]\n"
+        "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM] [-q NUM]\n"
+        "              [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
         stdout);
     exit(0);
 }


### PR DESCRIPTION
reasons:

* The interface is clunky to use
* Requires Imlib2 to be built with "text" support (which adds additional dependency).
* It's better done via an actual image editing software
* No one seems to be using it, since no one objected towards removing it in the discussions thread.

ref: https://github.com/resurrecting-open-source-projects/scrot/discussions/207
ref: https://github.com/resurrecting-open-source-projects/scrot/issues/236