### PR TITLE
ci: add aggressive gcc build with -fanalyzer

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -31,6 +31,14 @@ jobs:
         make -s distclean
         c99 -o src/scrot src/*.c $(pkg-config --cflags --libs ./deps.pc)
         src/scrot -v
+    - name: gcc-aggressive-fanalyzer
+      run: |
+        gcc --version
+        gcc -std=c99 -o src/scrot src/*.c -Wall -Wextra -Wpedantic -Werror \
+            -fanalyzer -O3 -flto -fuse-linker-plugin -fno-common \
+            -fgraphite-identity -floop-nest-optimize -fipa-pta \
+            $(pkg-config --cflags --libs ./deps.pc libbsd-overlay)
+        src/scrot -v
     - name: cppcheck
       run: |
         cppcheck --version


### PR DESCRIPTION
-fanalyzer used to throw out two warnings about memory leaks, but that seems to have been fixed with cc677e660daa53b3a8c60a18e0d0456eb322727a

also enables some aggressive gcc flags that aren't enabled by default even at -O3 (e.g graphite, ipa-pta).