### PR TITLE
src/Makefile.am: don't duplicate {CPP,C}FLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@
 # Copyright 2020-2021 Daniel T. Borelli <danieltborelli@gmail.com>
 # Copyright 2020      Jeroen Roovers <jer@gentoo.org>
 # Copyright 2021      Christopher R. Nelson <christopher.nelson@languidnights.com>
-# Copyright 2021      Guilherme Janczak <guilherme.janczak@yandex.com>
+# Copyright 2021,2023 Guilherme Janczak <guilherme.janczak@yandex.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -33,9 +33,6 @@ MAINTAINERCLEANFILES = Makefile.in
 
 
 bin_PROGRAMS  = scrot
-
-scrot_CPPFLAGS = @CPPFLAGS@
-scrot_LDADD    = @LIBS@
 scrot_SOURCES  = scrot.c scrot.h        \
 note.c note.h                           \
 options.c options.h                     \


### PR DESCRIPTION
Automake always uses {CPP,C}FLAGS to compile programs. We've been erroneously duplicating them into scrot_{C,CPP}FLAGS (per-target flags).

Ref: https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html