### PR TITLE
ci: add -Werror

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ common_template: &common_script
   name: ${OS}-${CC}
   build_script:
     - ./autogen.sh
-    - ./configure
+    - ./configure SCROT_PRIVATE_FLAGS="-Werror -Wno-error=cpp -Wno-error=pedantic"
     - make distcheck
   test_script:
     - make

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -20,7 +20,7 @@ jobs:
     - name: distcheck
       run: |
         ./autogen.sh
-        ./configure
+        ./configure SCROT_PRIVATE_FLAGS="-Werror -Wno-error=cpp -Wno-error=pedantic"
         make distcheck
     - name: run_program
       run: |
@@ -28,7 +28,7 @@ jobs:
         src/scrot -v
     - name: tcc
       run: |
-        ./configure CC=tcc
+        ./configure SCROT_PRIVATE_FLAGS="-Werror -Wno-error=cpp -Wno-error=pedantic" CC=tcc
         make clean all
         src/scrot -v
     - name: bare build
@@ -68,10 +68,12 @@ jobs:
                   libXcomposite-devel libXext-devel libXfixes-devel libXinerama-devel \
                   make
     - name: distcheck
+      # NOTE: cygwin's imlib2 version is too old, and it's imlib_apply_filter
+      # lacks `const` qualifier. so use `-Wno-error=discarded-qualifiers`.
       run: |
         cd ${GITHUB_WORKSPACE}
         ./autogen.sh
-        ./configure
+        ./configure SCROT_PRIVATE_FLAGS="-Werror -Wno-error=cpp -Wno-error=pedantic -Wno-error=discarded-qualifiers"
         make distcheck
     - name: run_program
       run: |

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,13 @@ AS_IF([test "x$orig_CFLAGS" = "x"], [
             ])
         ]
     )
+    # SCROT_PRIVATE_FLAGS are mainly used by the CI to append additional flags.
+    # append them unconditionally, the CI shouldn't try to add flags the
+    # compiler doesn't support.
+    AC_SUBST([CFLAGS], ["$CFLAGS $SCROT_PRIVATE_FLAGS"])
+    AS_IF([test "x$LTO_ENABLED" = "xyes"], [
+        AC_SUBST([LDFLAGS], ["$LDFLAGS $SCROT_PRIVATE_FLAGS"])
+    ])
 ])
 
 # Checks for libraries.
@@ -44,6 +51,10 @@ AC_ARG_ENABLE([libbsd-feature-test],
     AS_HELP_STRING([--enable-libbsd-feature-test],
         ["Do not configure the program, return true if libbsd is needed"]))
 AC_CHECK_FUNCS([err errx warn warnx],, [LIBBSD_NEEDED=yes])
+# TODO: header checks fail due to empty translation unit when -Wpedantic and
+# -Werror are both set. figure out a way to fix it and remove
+# -Wno-error=pedantic from the CI.
+# See also: https://github.com/resurrecting-open-source-projects/scrot/pull/333#issuecomment-1572157050
 AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes], [ ])
 # libbsd is obligatory on systems that don't have the BSD functions we use.
 # Pass "--enable-libbsd-feature-test" to ./configure, and the configure script

--- a/src/options.c
+++ b/src/options.c
@@ -315,6 +315,7 @@ static const char *getPathOfStdout(void)
             return paths[i];
     }
     err(EXIT_FAILURE, "access to stdout failed");
+    return 0; /* silence tcc warning */
 }
 
 void optionsParse(int argc, char *argv[])


### PR DESCRIPTION
this adds support for EXTRA_CFLAGS, which seems to be a common convention to append additional cflags. e.g neomutt uses it, linux kernel used to use it.

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/283