### PR TITLE
[WIP] Autogenerate shell completions

### DIFF
--- a/etc/compautogen.c
+++ b/etc/compautogen.c
@@ -1,0 +1,81 @@
+#include <limits.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+enum { no_argument, required_argument, optional_argument, };
+struct option {
+    const char *name;
+    int has_arg;
+    int *flag;
+    int val;
+    const char *desc;
+};
+
+#define DESC(X) X
+#include "../src/opts.h"
+enum { lopts_len = (sizeof(lopts) / sizeof(lopts[0])) - 1 };
+
+static bool isDeprecated(const struct option *o)
+{
+    return !strcmp(o->name, "note") || !strcmp(o->name, "script") ||
+        !strcmp(o->name, "focussed"); /* not deprecated, but no point in a double entry */
+}
+
+static int zsh(FILE *f)
+{
+    fputs("#compdef scrot\n\n", f);
+    fputs("_arguments \\\n", f);
+    for (const struct option *o = lopts, *end = o + lopts_len; o < end; ++o) {
+        if (isDeprecated(o))
+            continue;
+
+        fprintf(f, "\t'--%s", o->name);
+        if (o->desc)
+            fprintf(f, "[%s]", o->desc);
+        fprintf(f, "' \\\n");
+
+        if (o->val <= UCHAR_MAX) {
+            fprintf(f, "\t'-%c", o->val);
+            if (o->desc)
+                fprintf(f, "[%s]", o->desc);
+            fprintf(f, "' \\\n");
+        }
+    }
+    fputc('\n', f);
+    fflush(f);
+    return ferror(f);
+}
+
+static int bash(FILE *f)
+{
+    fputs("complete -W '", f);
+    for (const struct option *o = lopts, *end = o + lopts_len; o < end; ++o) {
+        if (isDeprecated(o))
+            continue;
+
+        fprintf(f, "--%s ", o->name);
+        if (o->val <= UCHAR_MAX)
+            fprintf(f, "-%c ", o->val);
+    }
+    fputs("' scrot\n", f);
+    fflush(f);
+    return ferror(f);
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        fprintf(stderr, "Usage: compautogen <zsh|bash>\n");
+        return 1;
+    }
+
+    char *s = argv[1];
+    if (!strcmp(s, "zsh"))
+        return zsh(stdout);
+    else if (!strcmp(s, "bash"))
+        return bash(stdout);
+
+    fprintf(stderr, "Unknown command\n");
+    return 1;
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,7 @@ MAINTAINERCLEANFILES = Makefile.in
 bin_PROGRAMS  = scrot
 scrot_SOURCES  = scrot.c scrot.h        \
 note.c note.h                           \
-options.c options.h                     \
+options.c options.h opts.h              \
 scrot_selection.c scrot_selection.h     \
 selection_classic.c selection_classic.h \
 selection_edge.c selection_edge.h       \

--- a/src/options.c
+++ b/src/options.c
@@ -52,6 +52,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <unistd.h>
 
 #include "note.h"
+#include "opts.h"
 #include "options.h"
 #include "scrot.h"
 #include "scrot_selection.h"
@@ -322,44 +323,6 @@ static const char *getPathOfStdout(void)
 
 void optionsParse(int argc, char *argv[])
 {
-    enum { /* long opt only */
-        /* ensure these don't collude with single byte opts. */
-        OPT_FORMAT = UCHAR_MAX + 1,
-    };
-    static char stropts[] = "a:bC:cD:d:e:F:fhik::l:M:mn:opq:S:s::t:uvw:Z:z";
-    static struct option lopts[] = {
-        {"autoselect",      required_argument,  NULL,   'a'},
-        {"border",          no_argument,        NULL,   'b'},
-        {"class",           required_argument,  NULL,   'C'},
-        {"count",           no_argument,        NULL,   'c'},
-        {"display",         required_argument,  NULL,   'D'},
-        {"delay",           required_argument,  NULL,   'd'},
-        {"exec",            required_argument,  NULL,   'e'},
-        {"file",            required_argument,  NULL,   'F'},
-        {"freeze",          no_argument,        NULL,   'f'},
-        {"help",            no_argument,        NULL,   'h'},
-        {"ignorekeyboard",  no_argument,        NULL,   'i'},
-        {"stack",           optional_argument,  NULL,   'k'},
-        {"line",            required_argument,  NULL,   'l'},
-        {"monitor",         required_argument,  NULL,   'M'},
-        {"multidisp",       no_argument,        NULL,   'm'},
-        {"note",            required_argument,  NULL,   'n'},
-        {"overwrite",       no_argument,        NULL,   'o'},
-        {"pointer",         no_argument,        NULL,   'p'},
-        {"quality",         required_argument,  NULL,   'q'},
-        {"script",          required_argument,  NULL,   'S'},
-        {"select",          optional_argument,  NULL,   's'},
-        {"thumb",           required_argument,  NULL,   't'},
-        {"focused",         no_argument,        NULL,   'u'},
-        /* macquarie dictionary has both spellings */
-        {"focussed",        no_argument,        NULL,   'u'},
-        {"version",         no_argument,        NULL,   'v'},
-        {"window",          required_argument,  NULL,   'w'},
-        {"compression",     required_argument,  NULL,   'Z'},
-        {"silent",          no_argument,        NULL,   'z'},
-        {"format",          required_argument,  NULL, OPT_FORMAT},
-        {0}
-    };
     int optch;
     const char *errmsg;
     bool FFlagSet = false;

--- a/src/opts.h
+++ b/src/opts.h
@@ -1,0 +1,43 @@
+#ifndef H_OPTS
+#define H_OPTS
+
+enum { /* long opt only */
+    /* ensure these don't collude with single byte opts. */
+    OPT_FORMAT = UCHAR_MAX + 1,
+};
+static const char stropts[] = "a:bC:cD:d:e:F:fhik::l:M:mn:opq:S:s::t:uvw:Z:z";
+static const struct option lopts[] = {
+    {"autoselect",      required_argument,  NULL,   'a'},
+    {"border",          no_argument,        NULL,   'b'},
+    {"class",           required_argument,  NULL,   'C'},
+    {"count",           no_argument,        NULL,   'c'},
+    {"display",         required_argument,  NULL,   'D'},
+    {"delay",           required_argument,  NULL,   'd'},
+    {"exec",            required_argument,  NULL,   'e'},
+    {"file",            required_argument,  NULL,   'F'},
+    {"freeze",          no_argument,        NULL,   'f'},
+    {"help",            no_argument,        NULL,   'h'},
+    {"ignorekeyboard",  no_argument,        NULL,   'i'},
+    {"stack",           optional_argument,  NULL,   'k'},
+    {"line",            required_argument,  NULL,   'l'},
+    {"monitor",         required_argument,  NULL,   'M'},
+    {"multidisp",       no_argument,        NULL,   'm'},
+    {"note",            required_argument,  NULL,   'n'},
+    {"overwrite",       no_argument,        NULL,   'o'},
+    {"pointer",         no_argument,        NULL,   'p'},
+    {"quality",         required_argument,  NULL,   'q'},
+    {"script",          required_argument,  NULL,   'S'},
+    {"select",          optional_argument,  NULL,   's'},
+    {"thumb",           required_argument,  NULL,   't'},
+    {"focused",         no_argument,        NULL,   'u'},
+    /* macquarie dictionary has both spellings */
+    {"focussed",        no_argument,        NULL,   'u'},
+    {"version",         no_argument,        NULL,   'v'},
+    {"window",          required_argument,  NULL,   'w'},
+    {"compression",     required_argument,  NULL,   'Z'},
+    {"silent",          no_argument,        NULL,   'z'},
+    {"format",          required_argument,  NULL, OPT_FORMAT},
+    {0}
+};
+
+#endif

--- a/src/opts.h
+++ b/src/opts.h
@@ -1,42 +1,94 @@
 #ifndef H_OPTS
 #define H_OPTS
 
+#ifndef DESC
+    #define DESC(X)
+#endif
+
 enum { /* long opt only */
     /* ensure these don't collude with single byte opts. */
     OPT_FORMAT = UCHAR_MAX + 1,
 };
 static const char stropts[] = "a:bC:cD:d:e:F:fhik::l:M:mn:opq:S:s::t:uvw:Z:z";
 static const struct option lopts[] = {
-    {"autoselect",      required_argument,  NULL,   'a'},
-    {"border",          no_argument,        NULL,   'b'},
+    {
+        "autoselect",      required_argument,  NULL,   'a',
+        DESC("autoselect region x,y,w,h")
+    },
+    {
+        "border",          no_argument,        NULL,   'b',
+        DESC("also grab the window border")
+    },
     {"class",           required_argument,  NULL,   'C'},
-    {"count",           no_argument,        NULL,   'c'},
+    {
+        "count",           no_argument,        NULL,   'c',
+        DESC("display a countdown for the delay")
+    },
     {"display",         required_argument,  NULL,   'D'},
-    {"delay",           required_argument,  NULL,   'd'},
+    {
+        "delay",           required_argument,  NULL,   'd',
+        DESC("specify a delay before screenshotting")
+    },
     {"exec",            required_argument,  NULL,   'e'},
-    {"file",            required_argument,  NULL,   'F'},
+    {
+        "file",            required_argument,  NULL,   'F',
+        DESC("specify the output file")
+    },
     {"freeze",          no_argument,        NULL,   'f'},
     {"help",            no_argument,        NULL,   'h'},
-    {"ignorekeyboard",  no_argument,        NULL,   'i'},
+    {
+        "ignorekeyboard",  no_argument,        NULL,   'i',
+        DESC("do not exit on keypress")
+    },
     {"stack",           optional_argument,  NULL,   'k'},
     {"line",            required_argument,  NULL,   'l'},
     {"monitor",         required_argument,  NULL,   'M'},
     {"multidisp",       no_argument,        NULL,   'm'},
     {"note",            required_argument,  NULL,   'n'},
-    {"overwrite",       no_argument,        NULL,   'o'},
-    {"pointer",         no_argument,        NULL,   'p'},
-    {"quality",         required_argument,  NULL,   'q'},
+    {
+        "overwrite",       no_argument,        NULL,   'o',
+        DESC("overwrite the output file if needed")
+    },
+    {
+        "pointer",         no_argument,        NULL,   'p',
+        DESC("capture the mouse pointer also")
+    },
+    {
+        "quality",         required_argument,  NULL,   'q',
+        DESC("specify output file quality")
+    },
     {"script",          required_argument,  NULL,   'S'},
-    {"select",          optional_argument,  NULL,   's'},
-    {"thumb",           required_argument,  NULL,   't'},
-    {"focused",         no_argument,        NULL,   'u'},
+    {
+        "select",          optional_argument,  NULL,   's',
+        DESC("interactively select a region to capture")
+    },
+    {
+        "thumb",           required_argument,  NULL,   't',
+        DESC("also generate a thumbnail")
+    },
+    {
+        "focused",         no_argument,        NULL,   'u',
+        DESC("use currently focused window")
+    },
     /* macquarie dictionary has both spellings */
     {"focussed",        no_argument,        NULL,   'u'},
     {"version",         no_argument,        NULL,   'v'},
-    {"window",          required_argument,  NULL,   'w'},
-    {"compression",     required_argument,  NULL,   'Z'},
-    {"silent",          no_argument,        NULL,   'z'},
-    {"format",          required_argument,  NULL, OPT_FORMAT},
+    {
+        "window",          required_argument,  NULL,   'w',
+        DESC("specify a window ID to capture")
+    },
+    {
+        "compression",     required_argument,  NULL,   'Z',
+        DESC("output file compression setting")
+    },
+    {
+        "silent",          no_argument,        NULL,   'z',
+        DESC("prevent beeping")
+    },
+    {
+        "format",          required_argument,  NULL, OPT_FORMAT,
+        DESC("specify the output format")
+    },
     {0}
 };
 


### PR DESCRIPTION
Recently someone mentioned [compleat](https://github.com/mbrubeck/compleat) and this made me realize we already have (almost) all the necessary information to generate shell completion in our `lopts` array.

So that's what this does. This is very much an early draft/proof of concept - so I'd like some feedback on the overall structure/direction of this (don't pay too much attention to small details at the moment).

Shells like zsh supports having a short description which can be helpful to the user, so I've added a `DESC` macro. But it's optional, so I can drop it if it's too invasive.

To test out the zsh completion yourself, run the following (or equivalent) and then reload your shell:

```console
$ tcc -run compautogen.c | doas tee /usr/local/share/zsh/site-functions/_scrot
```

Screenshot:

![image](https://github.com/resurrecting-open-source-projects/scrot/assets/79544946/62ca086c-c123-4ed9-8032-9a32948bee95)


- - -

UPDATE: I think the generator is at a state where it is good enough.

However a couple other things need to be done before the PR can be merged:

- [ ] Add a autoconf/make target (or script like the `create-man.sh`) to generate the output completion files
- [ ] Make sure the generated completion files are picked up by `make dist` (I'm thinking we shouldn't commit the generated files into git)
- [ ] Add the completions to `install` target as well

The last one might need more research since the "proper directory" to install completion files might vary distro to distro.

