### PR TITLE
fix: default extension if --format was used

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -93,6 +93,7 @@ SPECIAL STRINGS
 
     $$   A literal '$'.
     $a   The system's hostname.
+    $F   The output file format.
     $f   The image's full path (ignored when used in the filename).
     $h   The image's height.
     $m   The thumbnail's full path (ignored when used in the filename).

--- a/src/options.c
+++ b/src/options.c
@@ -64,6 +64,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     #define PACKAGE_VERSION "unknown"
 #endif
 
+static char defaultOutputFile[] = "%Y-%m-%d-%H%M%S_$wx$h_scrot.$F";
 struct ScrotOptions opt = {
     .quality = 75,
     .compression = 7,
@@ -73,7 +74,7 @@ struct ScrotOptions opt = {
     .stackDirection = HORIZONTAL,
     .monitor = -1,
     .windowId = None,
-    .outputFile = "%Y-%m-%d-%H%M%S_$wx$h_scrot.png",
+    .outputFile = defaultOutputFile,
     .lineColor = "gray",
 };
 
@@ -493,11 +494,21 @@ void optionsParse(int argc, char *argv[])
     for (; *argv; ++argv)
         warnx("ignoring extraneous non-option argument: %s", *argv);
 
+    if (!opt.format) {
+        char *ext = NULL;
+        scrotHaveFileExtension(opt.outputFile, &ext);
+        if (!ext || opt.outputFile == defaultOutputFile)
+            opt.format = "png";
+        else
+            opt.format = ext+1;
+    }
+
     if (strcmp(opt.outputFile, "-") == 0) {
         opt.overwrite = true;
         opt.thumb = THUMB_DISABLED;
         opt.outputFile = getPathOfStdout();
     }
+
     if (opt.thumb != THUMB_DISABLED)
         opt.thumbFile = optionsNameThumbnail(opt.outputFile);
 

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -70,7 +70,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 static void initXAndImlib(const char *, int);
 static void uninitXAndImlib(void);
-static size_t scrotHaveFileExtension(const char *, char **);
 static Imlib_Image scrotGrabFocused(void);
 static void applyFilterIfRequired(void);
 static Imlib_Image scrotGrabAutoselect(void);
@@ -104,7 +103,6 @@ int main(int argc, char *argv[])
     Imlib_Load_Error imErr;
     char *filenameIM = NULL;
     char *filenameThumb = NULL;
-    char *haveExtension = NULL;
     struct timespec timeStamp;
     struct tm *tm;
 
@@ -156,13 +154,7 @@ int main(int argc, char *argv[])
         scrotNoteDraw(image);
 
     imlib_context_set_image(image);
-    if (opt.format) {
-        imlib_image_set_format(opt.format);
-    } else {
-        scrotHaveFileExtension(opt.outputFile, &haveExtension);
-        if (!haveExtension)
-            imlib_image_set_format("png");
-    }
+    imlib_image_set_format(opt.format);
     imlib_image_attach_data_value("quality", NULL, opt.quality, NULL);
     imlib_image_attach_data_value("compression", NULL, opt.compression, NULL);
 
@@ -208,10 +200,7 @@ int main(int argc, char *argv[])
             errx(EXIT_FAILURE, "unable to create thumbnail");
         } else {
             imlib_context_set_image(thumbnail);
-            if (opt.format)
-                imlib_image_set_format(opt.format);
-            else if (!haveExtension)
-                imlib_image_set_format("png");
+            imlib_image_set_format(opt.format);
 
             filenameThumb = imPrintf(opt.thumbFile, tm, NULL, NULL, thumbnail);
             scrotCheckIfOverwriteFile(&filenameThumb);
@@ -280,7 +269,7 @@ static void uninitXAndImlib(void)
     }
 }
 
-static size_t scrotHaveFileExtension(const char *filename, char **ext)
+size_t scrotHaveFileExtension(const char *filename, char **ext)
 {
     char *s = strrchr(filename, '.');
 
@@ -676,6 +665,9 @@ static char *imPrintf(const char *str, struct tm *tm, const char *filenameIM,
                 gethostname(target, hostNameMax);
                 ret.off += strlen(target);
                 scrotAssert(ret.buf[ret.off] == '\0');
+                break;
+            case 'F':
+                streamStr(&ret, opt.format);
                 break;
             case 'f':
                 if (filenameIM)

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -47,5 +47,6 @@ struct timespec clockNow(void);
 struct timespec scrotSleepFor(struct timespec, int);
 void scrotDoDelay(void);
 Imlib_Image scrotGrabRectAndPointer(int x, int y, int w, int h);
+size_t scrotHaveFileExtension(const char *, char **);
 
 #endif /* !defined(H_SCROT) */


### PR DESCRIPTION
There's two commits, the first one dynamically grows the buffer to add the format to the extension.

The second commit makes things simpler by placing a limit on the format length, which is far greater any any existing image formats: https://en.wikipedia.org/wiki/Image_file_format

@guijan if you don't have any objection to the 2nd commit, then I'd like it keep it since it's simpler, avoids unnecessary "leak" and unnecessary failure points created by malloc.