### PR TITLE
selection: remove unnecessary allocations and indirections

### DIFF
--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -75,7 +75,6 @@ static void createCursors(void)
 static void freeCursors(void)
 {
     struct Selection *const sel = &selection;
-    scrotAssert(sel); /* silence clang-tidy */
 
     XFreeCursor(disp, sel->curCross);
     XFreeCursor(disp, sel->curAngleNE);
@@ -86,7 +85,7 @@ static void freeCursors(void)
 
 void selectionCalculateRect(int x0, int y0, int x1, int y1)
 {
-    struct SelectionRect *const rect = scrotSelectionGetRect();
+    struct SelectionRect *const rect = &selection.rect;
 
     rect->x = x0;
     rect->y = y0;
@@ -145,17 +144,10 @@ void scrotSelectionCreate(void)
 
 void scrotSelectionDestroy(void)
 {
-    struct Selection *const sel = &selection;
     XUngrabPointer(disp, CurrentTime);
     freeCursors();
     XSync(disp, True);
-    sel->destroy();
-}
-
-void scrotSelectionDraw(void)
-{
-    const struct Selection *const sel = &selection;
-    sel->draw();
+    selection.destroy();
 }
 
 void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)
@@ -174,11 +166,6 @@ void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)
         cursor = sel->curAngleNW;
     XChangeActivePointerGrab(disp, EVENT_MASK, cursor, CurrentTime);
     sel->motionDraw(x0, y0, x1, y1);
-}
-
-struct SelectionRect *scrotSelectionGetRect(void)
-{
-    return &(&selection)->rect;
 }
 
 Status scrotSelectionCreateNamedColor(const char *nameColor, XColor *color)
@@ -295,11 +282,11 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
             break;
         }
     }
-    scrotSelectionDraw();
+    selection.draw();
 
     XUngrabKeyboard(disp, CurrentTime);
 
-    const bool isAreaSelect = (scrotSelectionGetRect()->w > 5);
+    const bool isAreaSelect = (selection.rect.w > 5);
 
     scrotSelectionDestroy();
 

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -52,28 +52,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "selection_edge.h"
 #include "util.h"
 
-struct Selection **selectionGet(void)
-{
-    static struct Selection *sel = NULL;
-    return &sel;
-}
-
-static void selectionAllocate(void)
-{
-    struct Selection **sel = selectionGet();
-    *sel = ecalloc(1, sizeof(**sel));
-}
-
-static void selectionDeallocate(void)
-{
-    struct Selection **sel = selectionGet();
-    free(*sel);
-    *sel = NULL;
-}
+struct Selection selection;
 
 static void createCursors(void)
 {
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
 
     if (opt.selection.mode == SELECTION_MODE_CAPTURE)
         sel->curCross = XCreateFontCursor(disp, XC_cross);
@@ -91,7 +74,7 @@ static void createCursors(void)
 
 static void freeCursors(void)
 {
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
     scrotAssert(sel); /* silence clang-tidy */
 
     XFreeCursor(disp, sel->curCross);
@@ -129,9 +112,7 @@ void selectionCalculateRect(int x0, int y0, int x1, int y1)
 
 void scrotSelectionCreate(void)
 {
-    selectionAllocate();
-
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
 
     createCursors();
 
@@ -164,23 +145,22 @@ void scrotSelectionCreate(void)
 
 void scrotSelectionDestroy(void)
 {
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
     XUngrabPointer(disp, CurrentTime);
     freeCursors();
     XSync(disp, True);
     sel->destroy();
-    selectionDeallocate();
 }
 
 void scrotSelectionDraw(void)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
     sel->draw();
 }
 
 void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
     const unsigned int EVENT_MASK = ButtonMotionMask | ButtonReleaseMask;
     Cursor cursor = None;
 
@@ -198,7 +178,7 @@ void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)
 
 struct SelectionRect *scrotSelectionGetRect(void)
 {
-    return &(*selectionGet())->rect;
+    return &(&selection)->rect;
 }
 
 Status scrotSelectionCreateNamedColor(const char *nameColor, XColor *color)

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -112,6 +112,7 @@ void selectionCalculateRect(int x0, int y0, int x1, int y1)
 void scrotSelectionCreate(void)
 {
     struct Selection *const sel = &selection;
+    *sel = (struct Selection){0};
 
     createCursors();
 

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -38,7 +38,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <Imlib2.h>
 #include <X11/Xlib.h>
-#include <X11/Xutil.h>
 
 /* S: string, L: len */
 #define SELECTION_MODE_S_CAPTURE "capture"
@@ -89,7 +88,6 @@ struct SelectionClassic {
 };
 struct SelectionEdge {
     Window wndDraw;
-    XClassHint *classHint;
 };
 
 struct Selection {

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -98,7 +98,8 @@ struct Selection {
     void (*motionDraw)(int, int, int, int);
 };
 
-struct Selection **selectionGet(void);
+extern struct Selection selection;
+
 void selectionCalculateRect(int, int, int, int);
 void scrotSelectionCreate(void);
 void scrotSelectionDestroy(void);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -105,7 +105,6 @@ void scrotSelectionCreate(void);
 void scrotSelectionDestroy(void);
 void scrotSelectionDraw(void);
 void scrotSelectionMotionDraw(int, int, int, int);
-struct SelectionRect *scrotSelectionGetRect(void);
 void scrotSelectionGetLineColor(XColor *);
 Status scrotSelectionCreateNamedColor(const char *, XColor *);
 void scrotSelectionSetDefaultColorLine(void);

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -38,6 +38,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <Imlib2.h>
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 
 /* S: string, L: len */
 #define SELECTION_MODE_S_CAPTURE "capture"
@@ -82,15 +83,21 @@ typedef struct SelectionMode {
     const char *fileName;
 } SelectionMode;
 
-struct SelectionClassic;
-struct SelectionEdge;
+struct SelectionClassic {
+    XGCValues gcValues;
+    GC gc;
+};
+struct SelectionEdge {
+    Window wndDraw;
+    XClassHint *classHint;
+};
 
 struct Selection {
     Cursor curCross, curAngleNW, curAngleNE, curAngleSW, curAngleSE;
 
     struct SelectionRect rect;
-    struct SelectionClassic *classic;
-    struct SelectionEdge *edge;
+    struct SelectionClassic classic;
+    struct SelectionEdge edge;
 
     void (*create)(void);
     void (*destroy)(void);

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -50,7 +50,7 @@ struct SelectionClassic {
 
 void selectionClassicCreate(void)
 {
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
 
     sel->classic = ecalloc(1, sizeof(*sel->classic));
 
@@ -86,7 +86,7 @@ void selectionClassicCreate(void)
 
 void selectionClassicDraw(void)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
     const struct SelectionClassic *const pc = sel->classic;
     XDrawRectangle(disp, root, pc->gc, sel->rect.x, sel->rect.y, sel->rect.w,
         sel->rect.h);
@@ -95,7 +95,7 @@ void selectionClassicDraw(void)
 
 void selectionClassicMotionDraw(int x0, int y0, int x1, int y1)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
 
     if (sel->rect.w)
         selectionClassicDraw();
@@ -105,7 +105,7 @@ void selectionClassicMotionDraw(int x0, int y0, int x1, int y1)
 
 void selectionClassicDestroy(void)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
     struct SelectionClassic *pc = sel->classic;
 
     if (opt.freeze)

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -43,18 +43,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "selection_edge.h"
 #include "util.h"
 
-struct SelectionClassic {
-    XGCValues gcValues;
-    GC gc;
-};
-
 void selectionClassicCreate(void)
 {
     struct Selection *const sel = &selection;
-
-    sel->classic = ecalloc(1, sizeof(*sel->classic));
-
-    struct SelectionClassic *pc = sel->classic;
+    struct SelectionClassic *pc = &sel->classic;
 
     const unsigned long whiteColor = XWhitePixel(disp, 0);
     const unsigned long blackColor = XBlackPixel(disp, 0);
@@ -87,7 +79,7 @@ void selectionClassicCreate(void)
 void selectionClassicDraw(void)
 {
     const struct Selection *const sel = &selection;
-    const struct SelectionClassic *const pc = sel->classic;
+    const struct SelectionClassic *const pc = &sel->classic;
     XDrawRectangle(disp, root, pc->gc, sel->rect.x, sel->rect.y, sel->rect.w,
         sel->rect.h);
     XFlush(disp);
@@ -106,7 +98,7 @@ void selectionClassicMotionDraw(int x0, int y0, int x1, int y1)
 void selectionClassicDestroy(void)
 {
     const struct Selection *const sel = &selection;
-    struct SelectionClassic *pc = sel->classic;
+    const struct SelectionClassic *pc = &sel->classic;
 
     if (opt.freeze)
         XUngrabServer(disp);
@@ -114,6 +106,5 @@ void selectionClassicDestroy(void)
     if (pc->gc)
         XFreeGC(disp, pc->gc);
 
-    free(pc);
     XFlush(disp);
 }

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -53,7 +53,7 @@ struct SelectionEdge {
 
 void selectionEdgeCreate(void)
 {
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
 
     sel->edge = ecalloc(1, sizeof(*sel->edge));
 
@@ -91,7 +91,7 @@ void selectionEdgeCreate(void)
 
 void selectionEdgeDraw(void)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
     const struct SelectionEdge *const pe = sel->edge;
 
     XRectangle rects[4] = {
@@ -111,7 +111,7 @@ void selectionEdgeDraw(void)
 
 void selectionEdgeMotionDraw(int x0, int y0, int x1, int y1)
 {
-    struct Selection *const sel = *selectionGet();
+    struct Selection *const sel = &selection;
 
     selectionCalculateRect(x0, y0, x1, y1);
 
@@ -125,7 +125,7 @@ void selectionEdgeMotionDraw(int x0, int y0, int x1, int y1)
 
 void selectionEdgeDestroy(void)
 {
-    const struct Selection *const sel = *selectionGet();
+    const struct Selection *const sel = &selection;
     struct SelectionEdge *pe = sel->edge;
 
     if (pe->wndDraw != None) {

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -57,10 +57,6 @@ void selectionEdgeCreate(void)
     attr.background_pixel = color.pixel;
     attr.override_redirect = True;
 
-    pe->classHint = XAllocClassHint();
-    pe->classHint->res_name = "scrot";
-    pe->classHint->res_class = "scrot";
-
     pe->wndDraw = XCreateWindow(disp, root, 0, 0, WidthOfScreen(scr),
         HeightOfScreen(scr), 0, CopyFromParent, InputOutput, CopyFromParent,
         CWOverrideRedirect | CWBackPixel, &attr);
@@ -77,7 +73,8 @@ void selectionEdgeCreate(void)
         (unsigned char *) &(Atom) { XInternAtom(disp, "_NET_WM_WINDOW_TYPE_DOCK", False) },
         1L);
 
-    XSetClassHint(disp, pe->wndDraw, pe->classHint);
+    XClassHint hint = { .res_name = "scrot", .res_class = "scrot" };
+    XSetClassHint(disp, pe->wndDraw, &hint);
 }
 
 void selectionEdgeDraw(void)
@@ -134,7 +131,5 @@ void selectionEdgeDestroy(void)
          * adding latency. so wait a bit for the screen to update and the
          * selection borders to go away. */
         scrotSleepFor(clockNow(), 80);
-
-        XFree(pe->classHint);
     }
 }

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -46,18 +46,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "selection_edge.h"
 #include "util.h"
 
-struct SelectionEdge {
-    Window wndDraw;
-    XClassHint *classHint;
-};
-
 void selectionEdgeCreate(void)
 {
-    struct Selection *const sel = &selection;
-
-    sel->edge = ecalloc(1, sizeof(*sel->edge));
-
-    struct SelectionEdge *const pe = sel->edge;
+    struct SelectionEdge *const pe = &selection.edge;
 
     XColor color;
     scrotSelectionGetLineColor(&color);
@@ -92,7 +83,7 @@ void selectionEdgeCreate(void)
 void selectionEdgeDraw(void)
 {
     const struct Selection *const sel = &selection;
-    const struct SelectionEdge *const pe = sel->edge;
+    const struct SelectionEdge *const pe = &sel->edge;
 
     XRectangle rects[4] = {
         { sel->rect.x, sel->rect.y, opt.lineWidth, sel->rect.h }, // left
@@ -125,8 +116,7 @@ void selectionEdgeMotionDraw(int x0, int y0, int x1, int y1)
 
 void selectionEdgeDestroy(void)
 {
-    const struct Selection *const sel = &selection;
-    struct SelectionEdge *pe = sel->edge;
+    const struct SelectionEdge *pe = &selection.edge;
 
     if (pe->wndDraw != None) {
         XSelectInput(disp, pe->wndDraw, StructureNotifyMask);
@@ -147,6 +137,4 @@ void selectionEdgeDestroy(void)
 
         XFree(pe->classHint);
     }
-
-    free(pe);
 }


### PR DESCRIPTION
This patch series removes some unnecessary allocations and indirections from the selection code. Everything should still continue working as usual, no change in functionality is intended.

The PR may also be better viewed as [individual commits](https://github.com/resurrecting-open-source-projects/scrot/pull/339/commits), the commit messages contain a bit more details and rationale.