### PR TITLE
use the correct union type

### DIFF
--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -250,7 +250,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
         switch (ev.type) {
         case MotionNotify:
             if (isButtonPressed)
-                scrotSelectionMotionDraw(rx, ry, ev.xbutton.x, ev.xbutton.y);
+                scrotSelectionMotionDraw(rx, ry, ev.xmotion.x, ev.xmotion.y);
             break;
         case ButtonPress:
             isButtonPressed = true;
@@ -304,7 +304,7 @@ bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
                 goto key_abort_shot;
             }
             XFree(keysym);
-            scrotSelectionMotionDraw(rx, ry, ev.xbutton.x, ev.xbutton.y);
+            scrotSelectionMotionDraw(rx, ry, ev.xkey.x, ev.xkey.y);
             break;
         }
         case DestroyNotify:


### PR DESCRIPTION
MotionNotify returns a xmotion type and KeyPress returns a xkey type not an xbutton type.

but since the top members of xbutton, xmotion and xkey are the exact same, it happened to work out by accident.

ref: https://www.x.org/releases/X11R7.7/doc/man/man3/XButtonEvent.3.xhtml