### PR TITLE
replace dprintf() calls to fix the SmartOS port

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -332,12 +332,17 @@ void scrotDoDelay(void)
     if (!opt.delay)
         return;
     if (opt.countdown) {
-        dprintf(STDERR_FILENO, "Taking shot in ");
+        fputs("Taking shot in ", stderr);
         for (int i = opt.delay; i > 0; i--) {
-            dprintf(STDERR_FILENO, "%d.. ", i);
+            /* Illumos doesn't have dprintf():
+             * https://www.illumos.org/issues/1609
+             */
+            fprintf(stderr, "%d.. ", i);
+            fflush(stderr);
             opt.delayStart = scrotSleepFor(opt.delayStart, 1000);
         }
-        dprintf(STDERR_FILENO, "0.\n");
+        fprintf(stderr, "0.\n");
+        fflush(stderr);
     } else {
         scrotSleepFor(opt.delayStart, opt.delay * 1000);
     }


### PR DESCRIPTION
I don't have access to a SmartOS system, so I haven't tested it on SmartOS. I did test it on OpenBSD.

Fixes #346.