### PR TITLE
configure.ac: remove unsound/misleading flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ scrot requires a few projects and libraries:
 - A pkg-config implementation [(e.g. pkgconf)](https://github.com/pkgconf/pkgconf) (build time only)
 - [imlib2](https://sourceforge.net/projects/enlightenment/files/imlib2-src/)
   (must be built with X, text and filters support)
-- [libbsd](https://libbsd.freedesktop.org/wiki/) (if `./configure --enable-libbsd-feature-test` returns true)
+- [libbsd](https://libbsd.freedesktop.org/wiki/) (only needed if `<err.h>` or `<sys/queue.h>` is missing)
 - An X11 implementation [(e.g. X.Org)](https://www.x.org/wiki/)
 - libXcomposite [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxcomposite)
 - libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)

--- a/configure.ac
+++ b/configure.ac
@@ -47,28 +47,12 @@ AS_IF([test "x$orig_CFLAGS" = "x"], [
 # Checks for libraries.
 PKG_CHECK_MODULES([SCROT_DEPS], ["$srcdir/deps.pc"])
 
-AC_ARG_ENABLE([libbsd-feature-test],
-    AS_HELP_STRING([--enable-libbsd-feature-test],
-        ["Do not configure the program, return true if libbsd is needed"]))
 AC_CHECK_FUNCS([err errx warn warnx],, [LIBBSD_NEEDED=yes])
 # TODO: header checks fail due to empty translation unit when -Wpedantic and
 # -Werror are both set. figure out a way to fix it and remove
 # -Wno-error=pedantic from the CI.
 # See also: https://github.com/resurrecting-open-source-projects/scrot/pull/333#issuecomment-1572157050
 AC_CHECK_HEADERS([sys/queue.h],, [LIBBSD_NEEDED=yes], [ ])
-# libbsd is obligatory on systems that don't have the BSD functions we use.
-# Pass "--enable-libbsd-feature-test" to ./configure, and the configure script
-# will tell you whether the library is a dependency. This option is intended to
-# be used by package maintainers.
-AS_IF([test "x$enable_libbsd_feature_test" = "xyes"],
-    AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
-        AC_MSG_NOTICE([scrot depends on libbsd in the current system])
-        exit 0
-    ], [
-        AC_MSG_NOTICE([scrot does not depend on libbsd in the current system])
-        exit 1
-    ])
-)
 AS_IF([test "x$LIBBSD_NEEDED" = "xyes"], [
     PKG_CHECK_MODULES([LIBBSD], [libbsd-overlay],,
         [AC_MSG_ERROR([BSD functions not found, libbsd is required])])


### PR DESCRIPTION
this avoids misleading people due to the issues described in #315.

and packagers can already check the output of the configure script or config.log to see if libbsd was checked for or not.

additionally, document which bsd extension we require in the README so that maintainers can make more informed decision (e.g using more lightweight `sys/queue.h` in musl instead of heavyweight libbsd).

ref: https://github.com/resurrecting-open-source-projects/scrot/issues/307
Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/315