### PR TITLE
don't require a compositor for -k

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -42,8 +42,9 @@ OPTIONS
   -h, --help                Display help and exit.
   -i, --ignorekeyboard      Don't exit for keyboard input. ESC still exits.
   -k, --stack[=OPT]         Capture stack/overlapped windows and join them. A
-                            running Composite Manager is needed. OPT it's optional
-                            join letter: v/h (vertical/horizontal). Default: h
+                            running Composite Manager is needed for it to work
+                            correctly. OPT is optional join letter: v/h
+                            (vertical/horizontal). Default: h
   -l, --line STYLE          STYLE indicates the style of the line when the -s
                             option is used; see SELECTION STYLE.
   -M, --monitor NUM         Capture Xinerama monitor number NUM.

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -831,8 +831,8 @@ static Imlib_Image scrotGrabStackWindows(void)
 {
     if (XGetSelectionOwner(disp, XInternAtom(disp, "_NET_WM_CM_S0", False))
         == None) {
-        errx(EXIT_FAILURE, "option --stack: Composite Manager is not running,"
-            " required to use this option.");
+        warnx("option --stack: Composite Manager is not running,"
+            " some windows may overlap.");
     }
 
     unsigned long numberItemsReturn;


### PR DESCRIPTION
compositor doesn't seem to be needed and works fine without it. See: https://github.com/resurrecting-open-source-projects/scrot/pull/349#issuecomment-1606244433