### PR TITLE
fix: XImage memory leak

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -893,7 +893,7 @@ static Imlib_Image scrotGrabStackWindows(void)
                 "Failed to create Imlib2 image: Window id 0x%lx", win);
         }
 
-        XFree(ximage);
+        XDestroyImage(ximage);
 
         appendToScrotList(images, im);
     }


### PR DESCRIPTION
to free an XImage, XDestroyImage needs to be used, not XFree.