### PR TITLE
better handle mutually exclusive options

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -72,8 +72,6 @@ struct ScrotOptions opt = {
     .lineWidth = 1,
     .lineOpacity = SELECTION_OPACITY_DEFAULT,
     .stackDirection = HORIZONTAL,
-    .monitor = -1,
-    .windowId = None,
     .outputFile = defaultOutputFile,
     .lineColor = "gray",
 };
@@ -369,6 +367,7 @@ void optionsParse(int argc, char *argv[])
     while ((optch = getopt_long(argc, argv, stropts, lopts, NULL)) != -1) {
         switch (optch) {
         case 'a':
+            opt.mode = MODE_AUTOSEL;
             optionsParseAutoselect(optarg);
             break;
         case 'b':
@@ -411,13 +410,14 @@ void optionsParse(int argc, char *argv[])
             opt.ignoreKeyboard = true;
             break;
         case 'k':
-            opt.stack = true;
+            opt.mode = MODE_STACK;
             optionsParseStack(optarg);
             break;
         case 'l':
             optionsParseLine(optarg);
             break;
         case 'M':
+            opt.mode = MODE_MONITOR;
             opt.monitor = optionsParseNum(optarg, 0, INT_MAX, &errmsg);
             if (errmsg) {
                 errx(EXIT_FAILURE, "option --monitor: '%s' is %s", optarg,
@@ -425,7 +425,7 @@ void optionsParse(int argc, char *argv[])
             }
             break;
         case 'm':
-            opt.multidisp = true;
+            opt.mode = MODE_MULTIDISP;
             break;
         case 'n':
             if (optarg[0] == '\0')
@@ -449,18 +449,20 @@ void optionsParse(int argc, char *argv[])
             opt.script = optarg;
             break;
         case 's':
+            opt.mode = MODE_SELECT;
             optionsParseSelection(optarg);
             break;
         case 't':
             optionsParseThumbnail(optarg);
             break;
         case 'u':
-            opt.focused = true;
+            opt.mode = MODE_FOCUSED;
             break;
         case 'v':
             showVersion();
             break;
         case 'w':
+            opt.mode = MODE_WINDOW;
             opt.windowId = optionsParseNumBase(optarg, None/*0L*/, LONG_MAX, &errmsg, 0);
             if (errmsg) {
                 errx(EXIT_FAILURE, "option --window: '%s' is %s", optarg,
@@ -575,8 +577,6 @@ void optionsParseAutoselect(char *optarg)
                 errmsg);
         }
         i++;
-
-        opt.autoselect = true;
     }
     if (i < 4)
         errx(EXIT_FAILURE, "option --autoselect: too few dimensions");

--- a/src/options.h
+++ b/src/options.h
@@ -50,7 +50,19 @@ enum Direction {
     VERTICAL,
 };
 
+enum ShotMode {
+    MODE_SCREEN, /* first is the default one */
+    MODE_WINDOW,
+    MODE_AUTOSEL,
+    MODE_MONITOR,
+    MODE_STACK,
+    MODE_MULTIDISP,
+    MODE_FOCUSED,
+    MODE_SELECT,
+};
+
 struct ScrotOptions {
+    enum ShotMode mode;
     int delay;
     struct timespec delayStart;
     int quality;
@@ -84,14 +96,10 @@ struct ScrotOptions {
     bool countdown;
     bool border;
     bool silent;
-    bool focused;
     bool pointer;
     bool overwrite;
-    bool multidisp;
     bool freeze;
     bool ignoreKeyboard;
-    bool stack;
-    bool autoselect;
 };
 
 extern struct ScrotOptions opt;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -115,26 +115,28 @@ int main(int argc, char *argv[])
 
     initXAndImlib(opt.display, 0);
 
-    if (opt.selection.mode & SELECTION_MODE_ANY)
+    if (opt.mode == MODE_SELECT)
         image = scrotSelectionSelectMode();
     else {
 
         scrotDoDelay();
 
-        if (opt.focused)
+        if (opt.mode == MODE_FOCUSED)
             image = scrotGrabFocused();
-        else if (opt.multidisp)
+        else if (opt.mode == MODE_MULTIDISP)
             image = scrotGrabShotMulti();
-        else if (opt.stack)
+        else if (opt.mode == MODE_STACK)
             image = scrotGrabStackWindows();
-        else if (opt.monitor != -1)
+        else if (opt.mode == MODE_MONITOR)
             image = scrotGrabShotMonitor();
-        else if (opt.autoselect)
+        else if (opt.mode == MODE_AUTOSEL)
             image = scrotGrabAutoselect();
-        else if (opt.windowId != None)
+        else if (opt.mode == MODE_WINDOW)
             image = scrotGrabWindowById(opt.windowId);
-        else
+        else if (opt.mode == MODE_SCREEN)
             image = scrotGrabShot();
+        else
+            scrotAssert(!"unreachable");
     }
     if (!image)
         errx(EXIT_FAILURE, "no image grabbed");

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -98,7 +98,7 @@ Screen *scr;
 
 int main(int argc, char *argv[])
 {
-    Imlib_Image image;
+    Imlib_Image image = NULL;
     Imlib_Image thumbnail;
     Imlib_Load_Error imErr;
     char *filenameIM = NULL;


### PR DESCRIPTION
currently `scrot -s -u` will end up taking a screenshot with selection enabled even though `-u` was specified later. this patch makes scrot follow the cli convention of the later option overwriting the earlier one.

fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/264