### PR TITLE
fix undefined behavior with XComposite

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -864,6 +864,9 @@ static Imlib_Image scrotGrabStackWindows(void)
 
     initializeScrotList(images);
 
+    if (!XCompositeQueryVersion(disp, &(int){0}, &(int){0}))
+        errx(EXIT_FAILURE, "XCompositeQueryVersion() failed");
+
     XCompositeRedirectSubwindows(disp, root, CompositeRedirectAutomatic);
 
     for (i = 0; i < numberItemsReturn; i++) {


### PR DESCRIPTION
according to the XComposite manpage:

> No other XComposite functions (except XCompositeQueryExtension) may be
> called before XCompositeQueryVersion. If a client violates this rule,
> the effects of all subsequent XComposite calls that it makes are
> undefined.

fix it by calling XCompositeQueryVersion first.