### PR TITLE
reject empty filename earlier rather than later

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -509,6 +509,9 @@ void optionsParse(int argc, char *argv[])
         opt.outputFile = getPathOfStdout();
     }
 
+    if (opt.outputFile[0] == '\0')
+        errx(EXIT_FAILURE, "output filename cannot be empty");
+
     if (opt.thumb != THUMB_DISABLED)
         opt.thumbFile = optionsNameThumbnail(opt.outputFile);
 


### PR DESCRIPTION
currently `scrot ""` returns the following error message:

	scrot: strftime returned 0

which isn't very useful. reject empty filenames early on with a more descriptive error message instead.