### PR TITLE
fix: bad extension detection

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         cppcheck --version
         cppcheck --std=c99 -j$(nproc) --quiet --force --error-exitcode=1 \
+            --suppress=uninitvar \
             --enable=portability,performance src/*.c \
             $(pkg-config --cflags ./deps.pc)
     - name: clang-tidy

--- a/src/options.c
+++ b/src/options.c
@@ -528,13 +528,14 @@ static char *optionsNameThumbnail(const char *name)
     const ptrdiff_t nameLength = strlen(name);
     const char thumbSuffix[] = "-thumb";
     Stream ret = {0};
-    const char *const extension = strrchr(name, '.');
-    const ptrdiff_t baseNameLength = extension ? extension-name : nameLength;
+    char *extension = NULL;
+    size_t extLength = scrotHaveFileExtension(name, &extension);
+    const ptrdiff_t baseNameLength = nameLength - extLength;
 
     streamMem(&ret, name, baseNameLength);
     streamMem(&ret, thumbSuffix, sizeof(thumbSuffix)-1);
-    if (extension)
-        streamMem(&ret, extension, nameLength - baseNameLength);
+    if (extLength)
+        streamMem(&ret, extension, extLength);
     streamChar(&ret, '\0');
 
     return ret.buf;

--- a/src/options.c
+++ b/src/options.c
@@ -479,9 +479,9 @@ void optionsParse(int argc, char *argv[])
         warnx("ignoring extraneous non-option argument: %s", *argv);
 
     if (!opt.format) {
-        char *ext = NULL;
-        scrotHaveFileExtension(opt.outputFile, &ext);
-        if (!ext || opt.outputFile == defaultOutputFile)
+        char *ext;
+        size_t extLength = scrotHaveFileExtension(opt.outputFile, &ext);
+        if (extLength == 0 || opt.outputFile == defaultOutputFile)
             opt.format = "png";
         else
             opt.format = ext+1;
@@ -528,14 +528,13 @@ static char *optionsNameThumbnail(const char *name)
     const ptrdiff_t nameLength = strlen(name);
     const char thumbSuffix[] = "-thumb";
     Stream ret = {0};
-    char *extension = NULL;
+    char *extension;
     size_t extLength = scrotHaveFileExtension(name, &extension);
     const ptrdiff_t baseNameLength = nameLength - extLength;
 
     streamMem(&ret, name, baseNameLength);
     streamMem(&ret, thumbSuffix, sizeof(thumbSuffix)-1);
-    if (extLength)
-        streamMem(&ret, extension, extLength);
+    streamMem(&ret, extension, extLength);
     streamChar(&ret, '\0');
 
     return ret.buf;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -293,13 +293,8 @@ size_t scrotHaveFileExtension(const char *filename, char **ext)
     basename += *basename == '/';
     basename += *basename == '.'; /* dot files are not extensions */
     char *s = strrchr(basename, '.');
-
-    if (s && s[1] != '\0') {
-        *ext = s;
-        return strlen(s);
-    }
-
-    return 0;
+    *ext = (s && s[1] != '\0') ? s : "";
+    return strlen(*ext);
 }
 
 Imlib_Image scrotGrabRectAndPointer(int x, int y, int w, int h)
@@ -588,7 +583,7 @@ static void scrotCheckIfOverwriteFile(char **filename)
 
     extLength = scrotHaveFileExtension(*filename, &ext);
 
-    if (ext)
+    if (extLength)
         nalloc += extLength; // .ext
 
     newName = ecalloc(nalloc, sizeof(*newName));
@@ -599,7 +594,7 @@ static void scrotCheckIfOverwriteFile(char **filename)
 
         snprintf(fmt, sizeof(fmt), "_%03zu", counter++);
 
-        if (ext) {
+        if (extLength) {
             ptr -= extLength;
             memcpy(ptr, fmt, sizeof(fmt));
             memcpy(ptr + sizeof(fmt) - 1, ext, extLength);

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -287,7 +287,12 @@ static void scrotSaveImage(const char *filename)
 
 size_t scrotHaveFileExtension(const char *filename, char **ext)
 {
-    char *s = strrchr(filename, '.');
+    const char *basename = strrchr(filename, '/');
+    if (!basename)
+        basename = filename;
+    basename += *basename == '/';
+    basename += *basename == '.'; /* dot files are not extensions */
+    char *s = strrchr(basename, '.');
 
     if (s && s[1] != '\0') {
         *ext = s;


### PR DESCRIPTION
in a command like `scrot ~/.local/testfile` scrot will incorrectly think that `local/testfile` is the file extension and thus will try to use it as the output format.

ensure that the extension doesn't contain any slashes to avoid such issues.