### PR TITLE
better error reporting on newer imlib2 versions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,8 +17,8 @@ These will require a minimum version bump on imlib2 and so has to be done with
 care.
 
 - Switch to using `imlib_save_image_fd()` for saving images.
-- Switch to `imlib_get_error()` to retrieve the cause of error when saving and
-  loading images (and `imlib_strerror()` to stringify them).
+- ~~Switch to `imlib_get_error()` to retrieve the cause of error when saving and
+  loading images (and `imlib_strerror()` to stringify them).~~
 
 ## Integrate [libbsd](https://libbsd.freedesktop.org/wiki/)
 


### PR DESCRIPTION
currently, scrot's error message when saving a file fails is fairly non-informative. on imlib2 versions 1.10.0 and above we can use imlib_strerror() and imlib_get_error() to report the cause of failure more accurately.

since these functions require a fairly new version of imlib2, they've been guarded under ifdefs. in the future, if we require v1.10.0 as a minimum version then these ifdefs can be removed.