### PR TITLE
fix: buffer overrun due to bad x,y

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -887,7 +887,7 @@ static Imlib_Image scrotGrabStackWindows(void)
                 "option --stack: Failed XGetImage: Window id 0x%lx", win);
         }
 
-        im = imlib_create_image_from_ximage(ximage, NULL, attr.x, attr.y,
+        im = imlib_create_image_from_ximage(ximage, NULL, 0, 0,
             attr.width, attr.height, 1);
         if (!im) {
             errx(EXIT_FAILURE, "option --stack: "


### PR DESCRIPTION
imlib_create_image_from_ximage() expects x and y relative to the image itself and has no relation with the x,y position of the window.

which means we should pass 0 in both of them. otherwise, it'll try to read a width and height that's bigger than the image actually has.

buffer overflow was caught via AddressSanitizer.