### PR TITLE
more strict optional argument parsing

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -143,16 +143,10 @@ static bool optionsParseIsString(const char *const str)
 
 static void optionsParseStack(const char *optarg)
 {
-    // the suboption it's optional
-    if (!optarg) {
+    if (!optarg /* the suboption is optional */ || strcmp(optarg, "h") == 0)
         opt.stackDirection = HORIZONTAL;
-        return;
-    }
-
-    if (*optarg == 'v')
+    else if (strcmp(optarg, "v") == 0)
         opt.stackDirection = VERTICAL;
-    else if (*optarg == 'h')
-        opt.stackDirection = HORIZONTAL;
     else {
         errx(EXIT_FAILURE, "option --stack: Unknown value for suboption '%s'",
              optarg);

--- a/src/options.c
+++ b/src/options.c
@@ -148,20 +148,14 @@ static void optionsParseStack(const char *optarg)
         opt.stackDirection = HORIZONTAL;
         return;
     }
-    const char *value = strchr(optarg, '=');
 
-    if (value)
-        ++value;
-    else
-        value = optarg;
-
-    if (*value == 'v')
+    if (*optarg == 'v')
         opt.stackDirection = VERTICAL;
-    else if (*value == 'h')
+    else if (*optarg == 'h')
         opt.stackDirection = HORIZONTAL;
     else {
         errx(EXIT_FAILURE, "option --stack: Unknown value for suboption '%s'",
-             value);
+             optarg);
     }
 }
 
@@ -172,13 +166,7 @@ static void optionsParseSelection(const char *optarg)
         opt.selection.mode = SELECTION_MODE_CAPTURE;
         return;
     }
-
-    const char *value = strchr(optarg, '=');
-
-    if (value)
-        ++value;
-    else
-        value = optarg;
+    const char *value = optarg;
 
     if (!strncmp(value, SELECTION_MODE_S_CAPTURE, SELECTION_MODE_L_CAPTURE)) {
         opt.selection.mode = SELECTION_MODE_CAPTURE;


### PR DESCRIPTION
### fix weird optional argument parsing

currently if scrot is invoked like `scrot --stack=weird=v` then it
treats as if the argument to --stack was `v` and skips over "weird="
entirely.

the code here seems to be trying to get rid of the '=' but there's no
need for it, getopt_long() will remove the '=' already.

### optionsParseStack: parse more strictly

avoid treating `scrot --stack=v_trailing_stuff` as valid.
