### PR TITLE
Correct strftime manual section

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -88,7 +88,7 @@ OPTIONS
 SPECIAL STRINGS
   -e, -F and FILE parameters can take format specifiers that are expanded
   by scrot when encountered. There are two types of format specifier:
-  Characters preceded by a '%' are interpreted by strftime(2). The second kind
+  Characters preceded by a '%' are interpreted by strftime(3). The second kind
   are internal to scrot and are prefixed by '$'. The following specifiers are
   recognised by scrot:
 


### PR DESCRIPTION
Previously, scrot's manual mentioned the manual `strftime(2)`, which, as far as
I know it is incorrect. According to the Linux manpage `man-pages(7)`,  section
number `2` is for system calls and not for library functions.

I attempted searching for the manual `strftime(2)` to no avail with the command
`man -s 2 --names-only --wildcard 'strftime(2)'` and there are no lines with
the word `strftime` in the file `/usr/include/asm/unistd_64.h`, which has
system call numbers.
