### PR TITLE
autogen.sh shell script rewrite

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -29,29 +29,32 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
+[ "$#" -ge 1 ] && {
+    case "$1" in
+        (clean)
+            if [ -e Makefile ]; then
+                echo "I can not clean. Use 'make distclean'." >&2
+                exit 1
+            else
+                echo "Vanishing the code"
+                rm -rf aclocal.m4 autom4te.cache/ compile configure depcomp install-sh \
+                       Makefile.in missing src/config.h.in src/Makefile.in
+                exit
+            fi
+        ;;
+        (*)
+            echo "Invalid option '$1', maybe try running './${0##*/} clean'." >&2
 
-# Use clean option
-if [ "$1" = "clean" ] && [ ! -e Makefile ]
-then
-    echo "Vanishing the code"
-    rm -rf aclocal.m4 autom4te.cache/ compile configure depcomp install-sh \
-           Makefile.in missing src/config.h.in src/Makefile.in
-    exit 0
-fi
-
-# Do not use clean option
-if [ "$1" = "clean" ] && [ -e Makefile ]
-then
-    echo "I can not clean. Use '$ make distclean'."
-    exit 0
-fi
+            exit 1
+        ;;
+    esac
+}
 
 # Do autoreconf
-autoreconf -i \
-   && { echo " "; \
-        echo "Done. You can use the 'clean' option to vanish the source code."; \
-        echo "Example of use: $ ./autogen.sh clean"; \
-        echo " "; \
-        echo "Now run ./configure, make, and make install."; \
-      } \
-|| { echo "We have a problem..."; exit 1; }
+autoreconf -i && cat << MESSAGE
+
+Done. You can use the 'clean' option to vanish the source code.
+Usage example: './autogen.sh clean'
+
+Now run './configure', 'make', and 'make install'.
+MESSAGE


### PR DESCRIPTION
I have seen the pull request #174 by user @guijan, however, I disagree with the
code style and the argument against using `echo`.

I believe it is easier to validate the `autogen.sh` shell script command line
arguments and, albeit more readable by just expanding the first positional
parameter and ignoring the rest. Furthermore, the `autogen.sh` shell script
from #174 would consider an empty string as valid (e.g., `./autogen.sh ''`).

If the script were to become more complex, [arguments can be parsed in other ways](https://github.com/Kicksecure/sandbox-app-launcher/blob/master/usr/bin/sandbox-app-launcher#L8).

Regarding the use of the `echo` command, there should not be any significant
portability issue because all strings or arguments do not contain escape
sequences to be interpreted. When more formatting is required, `echo` can be
replaced to prevent errors because of the differences in their options. For
more information:

- https://man.openbsd.org/csh.1#echo
- https://man.openbsd.org/ksh.1#echo~2
- https://www.gnu.org/software/bash/manual/bash.html#index-echo
- https://git.kernel.org/pub/scm/utils/dash/dash.git/tree/src/bltin/printf.c#n458

While editing the `autogen.sh` shell script I noticed there was a
backslash near the end of a line with an `rm` command. Is there some line
length limit that I am not aware of?
