### PR TITLE
reject filenames with trailing slash

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -493,8 +493,11 @@ void optionsParse(int argc, char *argv[])
         opt.outputFile = getPathOfStdout();
     }
 
-    if (opt.outputFile[0] == '\0')
-        errx(EXIT_FAILURE, "output filename cannot be empty");
+    size_t outputFileLen = strlen(opt.outputFile);
+    if (outputFileLen == 0)
+        errx(EXIT_FAILURE, "output file cannot be empty");
+    if (opt.outputFile[outputFileLen - 1] == '/')
+        errx(EXIT_FAILURE, "output file cannot be a directory");
 
     if (opt.thumb != THUMB_DISABLED)
         opt.thumbFile = optionsNameThumbnail(opt.outputFile);


### PR DESCRIPTION
avoids funny situations later down the line such as creating `/tmp/_000` when invoked as `scrot /tmp/`

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/228