### PR TITLE
Add `--list-options` and shell completions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,7 @@ man_MANS = man/scrot.1
 
 dist_doc_DATA = AUTHORS ChangeLog CONTRIBUTING.md doc/scrot.png FAQ.md README.md TODO.md
 
-EXTRA_DIST = $(man_MANS) autogen.sh deps.pc
+EXTRA_DIST = $(man_MANS) autogen.sh deps.pc etc/
 
 SUBDIRS = src
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Debian users can install scrot from their package manager:
 $ sudo apt install scrot
 ```
 
+Bash and Zsh completion scripts are available in [etc/](./etc).
+Distro packagers are encouraged to install them to the appropriate directory.
+
 ## Author ##
 
 scrot was originally developed by Tom Gilbert.

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,17 @@ Look for any bugs reported downstream or in our github issues and fix them:
 - <https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&component=scrot&product=Fedora>
 - <https://bugs.gentoo.org/buglist.cgi?quicksearch=scrot>
 
+## Shell completion improvements
+
+- Improve the bash completion script. Currently it's quite rudimentary.
+- Filter out mutually exclusive options in zsh completion. E.g if `-b` is
+  already provided then `--border` should no longer be considered a potential
+  match.
+- Add some way to install zsh/bash completion scripts. Since the directory where
+  completion script go into can vary, we want the user to explicitly set the
+  installation directory. E.g via the configure script
+  `./configure --with-zsh-completion-path=...`.
+
 ## Switch to newer Imlib2 interfaces
 
 These will require a minimum version bump on imlib2 and so has to be done with

--- a/etc/bash-completion/scrot
+++ b/etc/bash-completion/scrot
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2024 NRK <nrk@disroot.org>
+#
+# This is free and unencumbered software released into the public domain.
+# For more information, please refer to <https://unlicense.org/>
+
+_scrot_autocomp() {
+	local -a _scrot_opt_list
+	IFS=$'\n' _scrot_opt_list=( $(scrot --list-options=tsv) ) 2>/dev/null
+	local _scrot_opts=""
+	for ln in "${_scrot_opt_list[@]}"; do
+		local -a tokens
+		IFS=$'\t' tokens=( ${ln} )
+
+		local sopt="${tokens[0]}"
+		local lopt="${tokens[1]}"
+		# TODO: better support for flags that accept argument
+		# local argtype=${tokens[2]%%:*}
+		# local argdesc=${tokens[2]#*:}
+		# local desc=${tokens[3]}
+		_scrot_opts+="--${lopt} "
+		if [[ "$sopt" = [[:alnum:]]* ]]; then
+			_scrot_opts+="-${sopt} "
+		fi
+	done
+	printf "%s" "${_scrot_opts% }"
+}
+complete -W "$(_scrot_autocomp)" scrot

--- a/etc/zsh-completion/_scrot
+++ b/etc/zsh-completion/_scrot
@@ -1,0 +1,30 @@
+#compdef scrot
+#
+# Copyright 2024 NRK <nrk@disroot.org>
+#
+# This is free and unencumbered software released into the public domain.
+# For more information, please refer to <https://unlicense.org/>
+
+local -a args
+local list=$($~words[1] --list-options=tsv) 2>/dev/null
+for ln in ${(f)list}; do
+    IFS=$'\t' local tokens=( ${=ln} )
+
+    local sopt="${tokens[1]}"
+    local lopt="${tokens[2]}"
+    local argtype=${tokens[3]%%:*}
+    local argdesc=${tokens[3]#*:}
+    local desc="[${tokens[4]}]"
+
+    case "$argtype" in
+        R) desc+=":$argdesc" ;; # Required
+        O) sopt+="+"; lopt+="=" ;; # Optional
+        N) ;; # None
+    esac
+
+    if [[ "${sopt}" = [[:alnum:]]* ]]; then
+        args+=( "-${sopt}${desc}" )
+    fi
+    args+=( "--${lopt}${desc}" )
+done
+_arguments "${args[@]}"

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -84,6 +84,10 @@ OPTIONS
                             extension to determine the format. If filename
                             does not have an extension either, then PNG will
                             be used as fallback.
+  --list-options[=OPT]      List all program options. If argument is "tsv" it
+                            outputs a TAB separated list intended for scripts.
+                            Default is "human". Note that the tsv format is not
+                            stable and may change in the future.
 
 SPECIAL STRINGS
   -e, -F and FILE parameters can take format specifiers that are expanded

--- a/src/options.c
+++ b/src/options.c
@@ -76,7 +76,85 @@ struct ScrotOptions opt = {
     .lineColor = "gray",
 };
 
+enum { /* long opt only */
+    /* ensure these don't collide with single byte opts. */
+    OPT_FORMAT = UCHAR_MAX + 1,
+    OPT_LIST_OPTS,
+};
+static const char stropts[] = "a:bC:cD:d:e:F:fhik::l:M:mn:opq:S:s::t:uvw:Z:z";
+// NOTE: make sure lopts and opt_description indexes are kept in sync
+static const struct option lopts[] = {
+    {"autoselect",      required_argument,  NULL,   'a'},
+    {"border",          no_argument,        NULL,   'b'},
+    {"class",           required_argument,  NULL,   'C'},
+    {"count",           no_argument,        NULL,   'c'},
+    {"display",         required_argument,  NULL,   'D'},
+    {"delay",           required_argument,  NULL,   'd'},
+    {"exec",            required_argument,  NULL,   'e'},
+    {"file",            required_argument,  NULL,   'F'},
+    {"freeze",          no_argument,        NULL,   'f'},
+    {"help",            no_argument,        NULL,   'h'},
+    {"ignorekeyboard",  no_argument,        NULL,   'i'},
+    {"stack",           optional_argument,  NULL,   'k'},
+    {"line",            required_argument,  NULL,   'l'},
+    {"monitor",         required_argument,  NULL,   'M'},
+    {"multidisp",       no_argument,        NULL,   'm'},
+    {"note",            required_argument,  NULL,   'n'},
+    {"overwrite",       no_argument,        NULL,   'o'},
+    {"pointer",         no_argument,        NULL,   'p'},
+    {"quality",         required_argument,  NULL,   'q'},
+    {"script",          required_argument,  NULL,   'S'},
+    {"select",          optional_argument,  NULL,   's'},
+    {"thumb",           required_argument,  NULL,   't'},
+    {"focused",         no_argument,        NULL,   'u'},
+    /* macquarie dictionary has both spellings */
+    {"focussed",        no_argument,        NULL,   'u'},
+    {"version",         no_argument,        NULL,   'v'},
+    {"window",          required_argument,  NULL,   'w'},
+    {"compression",     required_argument,  NULL,   'Z'},
+    {"silent",          no_argument,        NULL,   'z'},
+    {"format",          required_argument,  NULL, OPT_FORMAT},
+    {"list-options",    optional_argument,  NULL, OPT_LIST_OPTS},
+    {0}
+};
+static const char OPT_DEPRECATED[] = "";
+static const struct option_desc {
+    const char *description, *arg_description;
+} opt_description[] = {
+    /* a */  { "autoselect provided region", "x,y,w,h" },
+    /* b */  { "capture the window borders as well", "" },
+    /* C */  { "capture specified window class", "NAME" },
+    /* c */  { "display a countdown for delay", "" },
+    /* D */  { "capture specified display", "DISPLAY" },
+    /* d */  { "add delay before screenshot", "[b]SEC" },
+    /* e */  { "execute command on saved image", "CMD" },
+    /* F */  { "specify output file", "FILE" },
+    /* f */  { "freeze the screen when -s is used", "" },
+    /* h */  { "display help and exit", "" },
+    /* i */  { "ignore keyboard", "" },
+    /* k */  { "capture overlapped window and join them", "v|h" },
+    /* l */  { "specify the style of the selection line", "STYLE" },
+    /* M */  { "capture monitor", "NUM" },
+    /* m */  { "capture all monitors", "" },
+    /* n */  { OPT_DEPRECATED, OPT_DEPRECATED },
+    /* o */  { "overwrite the output file if needed", "" },
+    /* p */  { "capture the mouse pointer as well", "" },
+    /* q */  { "image quality", "NUM" },
+    /* S */  { OPT_DEPRECATED, OPT_DEPRECATED },
+    /* s */  { "interactively select a region to capture", "OPTS" },
+    /* t */  { "also generate a thumbnail", "% | WxH" },
+    /* u */  { "capture the currently focused window", "" },
+    /* u */  { "capture the currently focused window", "" },
+    /* v */  { "output version and exit", "" },
+    /* w */  { "X window ID to capture", "WID" },
+    /* Z */  { "image compression level", "LVL" },
+    /* z */  { "prevent beeping", "" },
+    /* OPT_FORMAT */     { "specify output file format", "FMT" },
+    /* OPT_LIST_OPTS */  { "list all options", "human|tsv" },
+};
+
 static void showUsage(void);
+static void showOptions(bool human);
 static void showVersion(void);
 static long long optionsParseNumBase(const char *, long long, long long,
     const char *[static 1], int);
@@ -302,82 +380,6 @@ static const char *getPathOfStdout(void)
 
 void optionsParse(int argc, char *argv[])
 {
-    enum { /* long opt only */
-        /* ensure these don't collude with single byte opts. */
-        OPT_FORMAT = UCHAR_MAX + 1,
-        OPT_LIST_OPTS,
-    };
-    static const char stropts[] = "a:bC:cD:d:e:F:fhik::l:M:mn:opq:S:s::t:uvw:Z:z";
-    // NOTE: make sure lopts and opt_description indexes are kept in sync
-    static const struct option lopts[] = {
-        {"autoselect",      required_argument,  NULL,   'a'},
-        {"border",          no_argument,        NULL,   'b'},
-        {"class",           required_argument,  NULL,   'C'},
-        {"count",           no_argument,        NULL,   'c'},
-        {"display",         required_argument,  NULL,   'D'},
-        {"delay",           required_argument,  NULL,   'd'},
-        {"exec",            required_argument,  NULL,   'e'},
-        {"file",            required_argument,  NULL,   'F'},
-        {"freeze",          no_argument,        NULL,   'f'},
-        {"help",            no_argument,        NULL,   'h'},
-        {"ignorekeyboard",  no_argument,        NULL,   'i'},
-        {"stack",           optional_argument,  NULL,   'k'},
-        {"line",            required_argument,  NULL,   'l'},
-        {"monitor",         required_argument,  NULL,   'M'},
-        {"multidisp",       no_argument,        NULL,   'm'},
-        {"note",            required_argument,  NULL,   'n'},
-        {"overwrite",       no_argument,        NULL,   'o'},
-        {"pointer",         no_argument,        NULL,   'p'},
-        {"quality",         required_argument,  NULL,   'q'},
-        {"script",          required_argument,  NULL,   'S'},
-        {"select",          optional_argument,  NULL,   's'},
-        {"thumb",           required_argument,  NULL,   't'},
-        {"focused",         no_argument,        NULL,   'u'},
-        /* macquarie dictionary has both spellings */
-        {"focussed",        no_argument,        NULL,   'u'},
-        {"version",         no_argument,        NULL,   'v'},
-        {"window",          required_argument,  NULL,   'w'},
-        {"compression",     required_argument,  NULL,   'Z'},
-        {"silent",          no_argument,        NULL,   'z'},
-        {"format",          required_argument,  NULL, OPT_FORMAT},
-        {"list-options",    optional_argument,  NULL, OPT_LIST_OPTS},
-        {0}
-    };
-    static const char OPT_DEPRECATED[] = "";
-    static const struct option_desc {
-        const char *description, *arg_description;
-    } opt_description[] = {
-        /* a */  { "autoselect provided region", "x,y,w,h" },
-        /* b */  { "capture the window borders as well", "" },
-        /* C */  { "capture specified window class", "NAME" },
-        /* c */  { "display a countdown for delay", "" },
-        /* D */  { "capture specified display", "DISPLAY" },
-        /* d */  { "add delay before screenshot", "[b]SEC" },
-        /* e */  { "execute command on saved image", "CMD" },
-        /* F */  { "specify output file", "FILE" },
-        /* f */  { "freeze the screen when -s is used", "" },
-        /* h */  { "display help and exit", "" },
-        /* i */  { "ignore keyboard", "" },
-        /* k */  { "capture overlapped window and join them", "v|h" },
-        /* l */  { "specify the style of the selection line", "STYLE" },
-        /* M */  { "capture monitor", "NUM" },
-        /* m */  { "capture all monitors", "" },
-        /* n */  { OPT_DEPRECATED, OPT_DEPRECATED },
-        /* o */  { "overwrite the output file if needed", "" },
-        /* p */  { "capture the mouse pointer as well", "" },
-        /* q */  { "image quality", "NUM" },
-        /* S */  { OPT_DEPRECATED, OPT_DEPRECATED },
-        /* s */  { "interactively select a region to capture", "OPTS" },
-        /* t */  { "also generate a thumbnail", "% | WxH" },
-        /* u */  { "capture the currently focused window", "" },
-        /* u */  { "capture the currently focused window", "" },
-        /* v */  { "output version and exit", "" },
-        /* w */  { "X window ID to capture", "WID" },
-        /* Z */  { "image compression level", "LVL" },
-        /* z */  { "prevent beeping", "" },
-        /* OPT_FORMAT */     { "specify output file format", "FMT" },
-        /* OPT_LIST_OPTS */  { "list all options", "human|tsv" },
-    };
     int optch;
     const char *errmsg;
     bool FFlagSet = false;
@@ -502,51 +504,16 @@ void optionsParse(int argc, char *argv[])
         case OPT_FORMAT:
             opt.format = optarg;
             break;
-        case OPT_LIST_OPTS: {
-            bool tsv = false;
-            if (optarg != NULL) {
-                if (strcmp(optarg, "tsv") == 0) {
-                    tsv = true;
-                } else if (strcmp(optarg, "human") == 0) {
-                    // no-op
-                } else {
-                    errx(EXIT_FAILURE,
-                        "unknown argument for --list-options: `%s`", optarg);
-                }
+        case OPT_LIST_OPTS:
+            if (optarg == NULL || strcmp(optarg, "human") == 0)
+                showOptions(true);
+            else if (strcmp(optarg, "tsv") == 0)
+                showOptions(false);
+            else {
+                errx(EXIT_FAILURE,
+                    "unknown argument for --list-options: `%s`", optarg);
             }
-
-            for (size_t i = 0; i < ARRAY_COUNT(opt_description); ++i) {
-                const struct option *o = &lopts[i];
-                const struct option_desc *d = &opt_description[i];
-                if (d->description == OPT_DEPRECATED)
-                    continue;
-
-                if (!tsv) {
-                    int n = 0;
-                    if (o->val <= UCHAR_MAX)
-                        n += printf("-%c, ", o->val);
-                    n += printf("--%s", o->name);
-                    if (o->has_arg == required_argument)
-                        n += printf(" <%s>", d->arg_description);
-                    else if (o->has_arg == optional_argument)
-                        n += printf("[=%s]", d->arg_description);
-                    for (; n >= 0 && n < 32; ++n)
-                        putchar(' ');
-                    printf("%s\n", d->description);
-                } else {
-                    printf("%c\t", o->val <= UCHAR_MAX ? o->val : ' ');
-                    printf("%s\t", o->name);
-                    if (o->has_arg == required_argument)
-                        printf("R:%s\t", d->arg_description);
-                    else if (o->has_arg == optional_argument)
-                        printf("O:%s\t", d->arg_description);
-                    else
-                        printf("N:\t");
-                    printf("%s\n", d->description);
-                }
-            }
-            exit(EXIT_SUCCESS);
-        } break;
+            break;
         default:
             exit(EXIT_FAILURE);
         }
@@ -595,12 +562,47 @@ void optionsParse(int argc, char *argv[])
 
 static void showUsage(void)
 {
-    fputs("usage:  " /* Check that everything lines up after any changes. */
-        PACKAGE_NAME " [-bcfhimopuvz] [-a X,Y,W,H] [-C NAME] [-D DISPLAY]\n"
-        "              [-d SEC] [-e CMD] [-k OPT] [-l STYLE] [-M NUM] [-q NUM]\n"
-        "              [-s OPTS] [-t % | WxH] [[-F] FILE]\n",
-        stdout);
+    fputs("Usage:  " PACKAGE_NAME " [OPTIONS...] [FILE]\n\n"
+          "A list of options with brief description is given below.\n"
+          "For more detailed description, "
+          "consult the "PACKAGE_NAME"(1) manpage.\n\n", stdout);
+    showOptions(true);
     exit(0);
+}
+
+static void showOptions(bool human)
+{
+    for (size_t i = 0; i < ARRAY_COUNT(opt_description); ++i) {
+        const struct option *o = &lopts[i];
+        const struct option_desc *d = &opt_description[i];
+        if (d->description == OPT_DEPRECATED)
+            continue;
+
+        if (human) {
+            int n = 0;
+            if (o->val <= UCHAR_MAX)
+                n += printf("-%c, ", o->val);
+            n += printf("--%s", o->name);
+            if (o->has_arg == required_argument)
+                n += printf(" <%s>", d->arg_description);
+            else if (o->has_arg == optional_argument)
+                n += printf("[=%s]", d->arg_description);
+            for (; n >= 0 && n < 32; ++n)
+                putchar(' ');
+            printf("%s\n", d->description);
+        } else {
+            printf("%c\t", o->val <= UCHAR_MAX ? o->val : ' ');
+            printf("%s\t", o->name);
+            if (o->has_arg == required_argument)
+                printf("R:%s\t", d->arg_description);
+            else if (o->has_arg == optional_argument)
+                printf("O:%s\t", d->arg_description);
+            else
+                printf("N:\t");
+            printf("%s\n", d->description);
+        }
+    }
+    exit(EXIT_SUCCESS);
 }
 
 static void showVersion(void)


### PR DESCRIPTION
This adds a `--list-options` flag which outputs a specialized TSV of all the options intended to be used in shell completion scripts. A couple TODOs:

- [x] Make `--list-options` accept an optional argument. By default it should output human readable format, but when using `--list-options=tsv` it would output the TSV.
- [ ] `make install` should install the zsh completion script
- [x] Completion script for bash
- [x] Add `--list-options` to manpage etc
- [x] Should `--help` output also include (human readable) list of options??