### PR TITLE
add sleep to classic selection destroy as well

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -16,17 +16,6 @@ into the selection area you have created.
 Use the `--ignorekeyboard` option. This option prevents exit by
 ignoring any keyboard event, except the <kbd>ESC</kbd> key.
 
-### The `--select` option leaves rectangle trails of the selection rectangle. How do I avoid this?
-
-There are 2 ways to solve this:
-
-Try first with: `scrot --select --freeze`
-
-Or using another selection mode: `scrot --select --line mode=edge`
-
-But this last one does not behave correctly with some
-CWM (Composite Window Manager)
-
 ### Does scrot have a class name?
 
 Yes. The class name is "scrot" and is useful only when using the

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -155,6 +155,11 @@ static void scrotSelectionDestroy(void)
     freeCursors();
     XSync(disp, True);
     selection.destroy();
+    /* HACK: although we destroyed the selection, the frame still might not
+     * have been updated. a compositor might also buffer frames adding
+     * latency. so wait a bit for the screen to update and the selection
+     * borders to go away. */
+    scrotSleepFor(clockNow(), 80);
 }
 
 static void scrotSelectionMotionDraw(int x0, int y0, int x1, int y1)

--- a/src/selection_edge.c
+++ b/src/selection_edge.c
@@ -126,10 +126,5 @@ void selectionEdgeDestroy(void)
             if (ev.type == UnmapNotify && ev.xunmap.window == pe->wndDraw)
                 is_unmapped = true;
         }
-        /* HACK: although we recived a DestroyNotify event, the frame still
-         * might not have been updated. a compositor might also buffer frames
-         * adding latency. so wait a bit for the screen to update and the
-         * selection borders to go away. */
-        scrotSleepFor(clockNow(), 80);
     }
 }


### PR DESCRIPTION
selection classic is still the default for many people who are using a compositor. adding a hacky sleep similar to selection edge seems to fix it on my end.

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/284