### PR TITLE
fix racy --freeze behavior

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -297,9 +297,9 @@ size_t scrotHaveFileExtension(const char *filename, char **ext)
     return strlen(*ext);
 }
 
-Imlib_Image scrotGrabRectAndPointer(int x, int y, int w, int h)
+Imlib_Image scrotGrabRectAndPointer(int x, int y, int w, int h, bool isGrabbed)
 {
-    Imlib_Image im = imlib_create_image_from_drawable(0, x, y, w, h, 1);
+    Imlib_Image im = imlib_create_image_from_drawable(0, x, y, w, h, !isGrabbed);
     if (!im)
         errx(EXIT_FAILURE, "failed to grab image");
     if (opt.pointer)
@@ -315,7 +315,7 @@ static Imlib_Image scrotGrabWindowById(Window const window)
     if (!scrotGetGeometry(window, &rx, &ry, &rw, &rh))
         return NULL;
     scrotNiceClip(&rx, &ry, &rw, &rh);
-    im = scrotGrabRectAndPointer(rx, ry, rw, rh);
+    im = scrotGrabRectAndPointer(rx, ry, rw, rh, false);
     clientWindow = window;
     return im;
 }
@@ -333,7 +333,7 @@ static Imlib_Image scrotGrabAutoselect(void)
     int rx = opt.autoselectX, ry = opt.autoselectY, rw = opt.autoselectW,
         rh = opt.autoselectH;
     scrotNiceClip(&rx, &ry, &rw, &rh);
-    return scrotGrabRectAndPointer(rx, ry, rw, rh);
+    return scrotGrabRectAndPointer(rx, ry, rw, rh, false);
 }
 
 void scrotDoDelay(void)
@@ -625,7 +625,7 @@ static Imlib_Image scrotGrabShot(void)
 {
     if (!opt.silent)
         XBell(disp, 0);
-    return scrotGrabRectAndPointer(0, 0, scr->width, scr->height);
+    return scrotGrabRectAndPointer(0, 0, scr->width, scr->height, false);
 }
 
 static void scrotExecApp(Imlib_Image image, struct tm *tm, char *filenameIM,
@@ -984,7 +984,7 @@ static Imlib_Image scrotGrabShotMonitor(void)
     XFree(screens);
 
     scrotNiceClip(&x, &y, &w, &h);
-    return scrotGrabRectAndPointer(x, y, w, h);
+    return scrotGrabRectAndPointer(x, y, w, h, false);
 }
 
 static Imlib_Image stalkImageConcat(

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -46,7 +46,7 @@ void scrotNiceClip(int *, int *, int *, int *);
 struct timespec clockNow(void);
 struct timespec scrotSleepFor(struct timespec, int);
 void scrotDoDelay(void);
-Imlib_Image scrotGrabRectAndPointer(int x, int y, int w, int h);
+Imlib_Image scrotGrabRectAndPointer(int, int, int, int, bool);
 size_t scrotHaveFileExtension(const char *, char **);
 
 #endif /* !defined(H_SCROT) */

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -71,9 +71,6 @@ void selectionClassicCreate(void)
 
     XSetLineAttributes(disp, pc->gc, opt.lineWidth, opt.lineStyle, CapRound,
         JoinRound);
-
-    if (opt.freeze)
-        XGrabServer(disp);
 }
 
 void selectionClassicDraw(void)
@@ -99,9 +96,6 @@ void selectionClassicDestroy(void)
 {
     const struct Selection *const sel = &selection;
     const struct SelectionClassic *pc = &sel->classic;
-
-    if (opt.freeze)
-        XUngrabServer(disp);
 
     if (pc->gc)
         XFreeGC(disp, pc->gc);


### PR DESCRIPTION
this patch makes a couple different changes:

* previously the grab/ungrab was happening inside of selection_classic::{create,destroy}. this meant that `--freeze` was ineffective when edge mode was used. the patch moves those calls outside of it, so that `--freeze` can work on edge mode as well.
* because the grab/ungrab was happening inside selection destroy, there were multiple races. one of them was that the server would be ungrabbed after selection was done but *before* the shot was captured. the sleep introduced in commit 93e475d widened the race window and made it more easily noticeable. the patch makes it so that we don't ungrab the server until the shot is actually taken.

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/381