### PR TITLE
(man page) add extra space to make -u line render as heading

### DIFF
--- a/man/scrot.1
+++ b/man/scrot.1
@@ -141,7 +141,10 @@ If one of the resolution's dimensions is 0, it is
 replaced by a number that maintains the full size
 screenshot's aspect ratio. Examples: 10, 25, 320x240,
 500x200, 100x0, 0x480.
-\fB-u\fP, \fB--focused\fP, \fB--focussed\fP Use the currently focused window.
+.TP
+.B
+\fB-u\fP, \fB--focused\fP, \fB--focussed\fP
+Use the currently focused window.
 .TP
 .B
 \fB-v\fP, \fB--version\fP

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -69,7 +69,7 @@ OPTIONS
                             replaced by a number that maintains the full size
                             screenshot's aspect ratio. Examples: 10, 25, 320x240,
                             500x200, 100x0, 0x480.
-  -u, --focused, --focussed Use the currently focused window.
+  -u, --focused, --focussed  Use the currently focused window.
   -v, --version             Output version information and exit.
   -w, --window WID          Window identifier to capture.
                             WID must be a valid identifier (see xwininfo(1)).


### PR DESCRIPTION
![2024-09-14_14-52-10-552210690](https://github.com/user-attachments/assets/68154057-9a8b-411c-800f-8d0f90fcec1c)

The line in the man page for `-u, focused, --focussed` is not being rendered properly. Adding an extra space between the flags and the description in scrot.txt fixes this.

This does put it out of line with the rest of the descriptions...