### PR TITLE
XSync after selection.destroy() not before

### DIFF
--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -160,8 +160,8 @@ static void scrotSelectionDestroy(void)
 {
     XUngrabPointer(disp, CurrentTime);
     freeCursors();
-    XSync(disp, True);
     selection.destroy();
+    XSync(disp, False);
     /* HACK: although we destroyed the selection, the frame still might not
      * have been updated. a compositor might also buffer frames adding
      * latency. so wait a bit for the screen to update and the selection

--- a/src/selection_classic.c
+++ b/src/selection_classic.c
@@ -99,6 +99,4 @@ void selectionClassicDestroy(void)
 
     if (pc->gc)
         XFreeGC(disp, pc->gc);
-
-    XFlush(disp);
 }


### PR DESCRIPTION
removes XFlush from selectionClassicDestroy as it's now redundant.

also changes discard argument to false, not sure why it was true to begin with.

Maybe-fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/387