### PR TITLE
replace xinerama with xrandr

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -53,7 +53,7 @@ task:
   install_script:
     - apk add build-base autoconf autoconf-archive automake gzip pkgconfig $CC
               xorg-server-dev libxcomposite-dev libxext-dev libxfixes-dev
-              libxinerama-dev imlib2-dev
+              libxrandr-dev imlib2-dev
   << : *common_script
 
 task:
@@ -77,7 +77,7 @@ task:
     - apt-get update
     - apt-get install -y autoconf autoconf-archive make pkg-config $CC
                          libx11-dev libxcomposite-dev libxext-dev libxfixes-dev
-                         libxinerama-dev libimlib2-dev
+                         libxrandr-dev libimlib2-dev
   << : *common_script
 
 task:
@@ -92,7 +92,7 @@ task:
       - CC: gcc
   install_script:
     - pkg install -y autoconf autoconf-archive automake pkgconf gcc libX11
-                     libXcomposite libXext libXfixes libXinerama imlib2
+                     libXcomposite libXext libXfixes libXrandr imlib2
   << : *common_script
 
 task:
@@ -108,7 +108,7 @@ task:
   install_script:
     - brew update
     - brew install autoconf autoconf-archive automake make pkg-config gcc libx11
-                   libxcomposite libxext libxfixes libxinerama imlib2
+                   libxcomposite libxext libxfixes libxrandr imlib2
   << : *common_script
 
 task:
@@ -118,7 +118,7 @@ task:
   install_script:
     - apk add build-base pkgconfig
               xorg-server-dev libxcomposite-dev libxext-dev
-              libxfixes-dev libxinerama-dev imlib2-dev
+              libxfixes-dev libxrandr-dev imlib2-dev
   matrix:
     - name: alpine-latest-bare-build
       test_script:

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -17,7 +17,7 @@ jobs:
     - name: install_dependencies
       run: |
         sudo apt install tcc libimlib2-dev libxcomposite-dev libxfixes-dev \
-             autoconf-archive libbsd-dev libxinerama-dev cppcheck
+             autoconf-archive libbsd-dev libxrandr-dev cppcheck
     - name: distcheck
       run: |
         ./autogen.sh

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ scrot requires a few projects and libraries:
 - libXcomposite [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxcomposite)
 - libXext [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxext)
 - libXfixes [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxfixes)
-- libXinerama [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxinerama)
+- libXrandr [(can be found in X.Org)](https://gitlab.freedesktop.org/xorg/lib/libxrandr)
 
 The [deps.pc](./deps.pc) file documents minimum version requirement for some of
 the libraries.

--- a/deps.pc
+++ b/deps.pc
@@ -2,4 +2,4 @@ Name: scrot's mandatory dependencies
 Description: ditto
 Version: infinite
 Cflags: -D_XOPEN_SOURCE=700L
-Requires: x11 imlib2 >= 1.11.0 xcomposite >= 0.2.0 xext xfixes >= 5.0.1 xinerama >= 1.1.3
+Requires: x11 imlib2 >= 1.11.0 xcomposite >= 0.2.0 xext xfixes >= 5.0.1 xrandr >= 1.5

--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -47,7 +47,7 @@ OPTIONS
                             (vertical/horizontal). Default: h
   -l, --line STYLE          STYLE indicates the style of the line when the -s
                             option is used; see SELECTION STYLE.
-  -M, --monitor NUM         Capture Xinerama monitor number NUM.
+  -M, --monitor NUM         Capture Xrandr monitor number NUM.
   -m, --multidisp           For multiple heads, screenshot all of them in order.
   -o, --overwrite           By default scrot does not overwrite the output
                             FILE, use this option to enable it.

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -61,7 +61,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <X11/Xutil.h>
 #include <X11/extensions/Xcomposite.h>
 #include <X11/extensions/Xfixes.h>
-#include <X11/extensions/Xinerama.h>
+#include <X11/extensions/Xrandr.h>
 
 #include "options.h"
 #include "scrot.h"
@@ -949,27 +949,17 @@ static Imlib_Image scrotGrabShotMulti(void)
 
 static Imlib_Image scrotGrabShotMonitor(void)
 {
-    int eventBase, errBase;
+    int numMonitors;
+    XRRMonitorInfo *monitors = XRRGetMonitors(disp, root, True, &numMonitors);
+    if (!monitors)
+        errx(EXIT_FAILURE, "XRRGetMonitors() failed");
 
-    if (!XineramaQueryExtension(disp, &eventBase, &errBase))
-        errx(EXIT_FAILURE, "Xinerama extension not found");
-
-    int numScreens = 0;
-    XineramaScreenInfo *screens = XineramaQueryScreens(disp, &numScreens);
-
-    if (!screens && !numScreens)
-        errx(EXIT_FAILURE, "Xinerama not active");
-
-    if (!numScreens)
-        errx(EXIT_FAILURE, "Xinerama active but did not find any output device");
-
-    if (opt.monitor >= numScreens)
+    if (opt.monitor >= numMonitors)
         errx(EXIT_FAILURE, "monitor %d not found", opt.monitor);
 
-    scrotAssert(screens); /* silence clang-tidy */
-    XineramaScreenInfo *mon = &screens[opt.monitor];
-    int x = mon->x_org, y = mon->y_org, w = mon->width, h = mon->height;
-    XFree(screens);
+    XRRMonitorInfo *m = monitors + opt.monitor;
+    int x = m->x, y = m->y, h = m->height, w = m->width;
+    XRRFreeMonitors(monitors);
 
     scrotNiceClip(&x, &y, &w, &h);
     return scrotGrabRectAndPointer(x, y, w, h, false);


### PR DESCRIPTION
xrandr is supposedly the [better replacement](https://wiki.archlinux.org/title/Multihead#Xinerama) for xinerama. On my system, no packages (other than scrot) use xinerama while there's a bunch using xrandr, so it's likely a more common dependency which is probably already installed too.

Alternatively, instead of replacing it we could offer a build time config switch allowing the user to select between xrandr and xinerama.