### PR TITLE
with --freeze capture immidately and crop later

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -88,7 +88,6 @@ static Window scrotFindWindowByProperty(Display *, const Window, const Atom);
 static Imlib_Image stalkImageConcat(Imlib_Image *, size_t, const enum Direction);
 static int findWindowManagerFrame(Window *const, int *const);
 static Imlib_Image scrotGrabWindowById(Window const window);
-static void scrotGrabMousePointer(Imlib_Image, const int, const int);
 
 /* X11 stuff */
 Display *disp;
@@ -520,7 +519,7 @@ Window scrotGetWindow(Display *display, Window window, int x, int y)
     return target;
 }
 
-static void scrotGrabMousePointer(Imlib_Image image, const int xOffset,
+void scrotGrabMousePointer(Imlib_Image image, const int xOffset,
     const int yOffset)
 {
     XFixesCursorImage *xcim = XFixesGetCursorImage(disp);

--- a/src/scrot.h
+++ b/src/scrot.h
@@ -47,6 +47,7 @@ struct timespec clockNow(void);
 struct timespec scrotSleepFor(struct timespec, int);
 void scrotDoDelay(void);
 Imlib_Image scrotGrabRectAndPointer(int, int, int, int, bool);
+void scrotGrabMousePointer(Imlib_Image, const int, const int);
 size_t scrotHaveFileExtension(const char *, char **);
 
 #endif /* !defined(H_SCROT) */

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -402,6 +402,7 @@ static Imlib_Image loadImage(const char *const fileName, const int opacity)
 Imlib_Image scrotSelectionSelectMode(void)
 {
     struct SelectionRect rect0, rect1;
+    Imlib_Image capture;
 
     const unsigned int oldMode = opt.selection.mode;
     opt.selection.mode = SELECTION_MODE_CAPTURE;
@@ -420,36 +421,51 @@ Imlib_Image scrotSelectionSelectMode(void)
     if (opt.delaySelection)
         scrotDoDelay();
 
-    if (opt.freeze)
+    if (opt.freeze) {
         XGrabServer(disp);
+        // capture immidately to avoid the selection making a mess later
+        capture = imlib_create_image_from_drawable(0, 0, 0,
+            scr->width, scr->height, false);
+        if (!capture)
+            errx(EXIT_FAILURE, "Failed to grab image");
+    }
 
-    bool success = scrotSelectionGetUserSel(&rect0);
-    if (success) {
+    bool selected = scrotSelectionGetUserSel(&rect0);
+    if (selected) {
         opt.selection.mode = oldMode;
         if (opt.selection.mode & SELECTION_MODE_NOT_CAPTURE)
-            success = scrotSelectionGetUserSel(&rect1);
+            selected = scrotSelectionGetUserSel(&rect1);
     }
 
-    if (!success) {
-        if (opt.freeze) {
-            XUngrabServer(disp);
-            XFlush(disp);
-        }
-        return NULL;
-    }
-
-    // this doesn't seem to make much sense if `--freeze` is enabled...
-    if (!opt.delaySelection) {
+    if (selected && !opt.delaySelection) {
+        // this doesn't seem to make much sense if `--freeze` is enabled...
         opt.delayStart = clockNow();
         scrotDoDelay();
     }
 
-    Imlib_Image capture = scrotGrabRectAndPointer(
-        rect0.x, rect0.y, rect0.w, rect0.h, opt.freeze);
-
     if (opt.freeze) {
         XUngrabServer(disp);
         XFlush(disp);
+        // captured already, just crop it
+        imlib_context_set_image(capture);
+        if (selected) {
+            capture = imlib_create_cropped_image(
+                rect0.x, rect0.y, rect0.w, rect0.h);
+        } else {
+            capture = NULL;
+        }
+        imlib_free_image(); // frees original capture that's in context
+        if (capture && opt.pointer)
+            scrotGrabMousePointer(capture, rect0.x, rect0.y);
+    } else if (selected) {
+        capture = scrotGrabRectAndPointer(
+            rect0.x, rect0.y, rect0.w, rect0.h, opt.freeze);
+    }
+
+    if (capture == NULL) {
+        if (selected)
+            errx(EXIT_FAILURE, "Failed to grab image");
+        return NULL;
     }
 
     if (opt.selection.mode == SELECTION_MODE_CAPTURE)


### PR DESCRIPTION
this reworks how --freeze handles capture to make it so that it grabs the full sized image immediately and then later crop it according to the selection.

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/387
Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/408