### PR TITLE
don't default to edge when --freeze is given

### DIFF
--- a/man/scrot.txt
+++ b/man/scrot.txt
@@ -169,9 +169,9 @@ SELECTION STYLE
 
     mode=MODE       MODE can be "auto", "edge" or "classic" without quotes.
                     edge is the new selection, classic uses the old one.
-                    "auto" uses "edge" if no compositor is running, "classic"
-                    otherwise. "edge" ignores the style specifier, "classic"
-                    ignores the opacity specifier.
+                    "auto" uses "edge" if no compositor is running and -f flag
+                    isn't active, "classic" otherwise. "edge" ignores the style
+                    specifier, "classic" ignores the opacity specifier.
 
   Without the -l option, a default style is used:
 

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -410,8 +410,10 @@ Imlib_Image scrotSelectionSelectMode(void)
         char buf[128];
         snprintf(buf, sizeof(buf), "_NET_WM_CM_S%d", DefaultScreen(disp));
         Atom cm = XInternAtom(disp, buf, False);
-        /* use edge mode if no compositor is running */
-        if (XGetSelectionOwner(disp, cm) == None)
+        /* edge mode has some issues with compositor.
+         * also doesn't work well in combination with --freeze.
+         */
+        if (XGetSelectionOwner(disp, cm) == None && !opt.freeze)
             opt.lineMode = LINE_MODE_EDGE;
         else
             opt.lineMode = LINE_MODE_CLASSIC;


### PR DESCRIPTION
edge mode never used to work with -f until commit c60a26c.
and it seems to be causing a lot of artifacts. so don't default
to it if --freeze is active.

Ref: https://github.com/resurrecting-open-source-projects/scrot/issues/408