### PR TITLE
always ring the bell after taking the shot

### DIFF
--- a/src/scrot.c
+++ b/src/scrot.c
@@ -151,6 +151,11 @@ int main(int argc, char *argv[])
     }
     tm = localtime(&timeStamp.tv_sec);
 
+    if (!opt.silent) {
+        XBell(disp, 0);
+        XFlush(disp);
+    }
+
     if (opt.note)
         scrotNoteDraw(image);
 
@@ -624,8 +629,6 @@ static int scrotMatchWindowClassName(Window target)
 
 static Imlib_Image scrotGrabShot(void)
 {
-    if (!opt.silent)
-        XBell(disp, 0);
     return scrotGrabRectAndPointer(0, 0, scr->width, scr->height, false);
 }
 

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -345,9 +345,6 @@ static bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
     }
     scrotNiceClip(&rx, &ry, &rw, &rh);
 
-    if (!opt.silent)
-        XBell(disp, 0);
-
     selectionRect->x = rx;
     selectionRect->y = ry;
     selectionRect->w = rw;


### PR DESCRIPTION
currently it only rings it after certain cases but not all. move the bell ringing outside of grab mode specific code and into main() where it will be consistently rang in case of a successful capture regardless of grab mode.

Fixes: https://github.com/resurrecting-open-source-projects/scrot/issues/412