### PR TITLE
Removed focussed option and simplified zsh completion

### DIFF
--- a/etc/zsh-completion/_scrot
+++ b/etc/zsh-completion/_scrot
@@ -14,17 +14,17 @@ for ln in ${(f)list}; do
     local lopt="${tokens[2]}"
     local argtype=${tokens[3]%%:*}
     local argdesc=${tokens[3]#*:}
-    local desc="[${tokens[4]}]"
+    if [[ "${sopt}" = [[:alnum:]]* ]]; then 
+        local desc="[(-${sopt}) ${tokens[4]}]"
+    else 
+        local desc="[     ${tokens[4]}]"
+    fi
 
     case "$argtype" in
         R) desc+=":$argdesc" ;; # Required
         O) sopt+="+"; lopt+="=" ;; # Optional
         N) ;; # None
     esac
-
-    if [[ "${sopt}" = [[:alnum:]]* ]]; then
-        args+=( "-${sopt}${desc}" )
-    fi
     args+=( "--${lopt}${desc}" )
 done
 _arguments "${args[@]}"

--- a/man/scrot.1
+++ b/man/scrot.1
@@ -143,7 +143,7 @@ screenshot's aspect ratio. Examples: 10, 25, 320x240,
 500x200, 100x0, 0x480.
 .TP
 .B
-\fB-u\fP, \fB--focused\fP, \fB--focussed\fP
+\fB-u\fP, \fB--focused\fP
 Use the currently focused window.
 .TP
 .B

--- a/src/options.c
+++ b/src/options.c
@@ -107,8 +107,6 @@ static const struct option lopts[] = {
     {"select",          optional_argument,  NULL,   's'},
     {"thumb",           required_argument,  NULL,   't'},
     {"focused",         no_argument,        NULL,   'u'},
-    /* macquarie dictionary has both spellings */
-    {"focussed",        no_argument,        NULL,   'u'},
     {"version",         no_argument,        NULL,   'v'},
     {"window",          required_argument,  NULL,   'w'},
     {"compression",     required_argument,  NULL,   'Z'},
@@ -143,7 +141,6 @@ static const struct option_desc {
     /* S */  { OPT_DEPRECATED, OPT_DEPRECATED },
     /* s */  { "interactively select a region to capture", "OPTS" },
     /* t */  { "also generate a thumbnail", "% | WxH" },
-    /* u */  { "capture the currently focused window", "" },
     /* u */  { "capture the currently focused window", "" },
     /* v */  { "output version and exit", "" },
     /* w */  { "X window ID to capture", "WID" },


### PR DESCRIPTION
Removed the alternate spelling of focused (ie focussed) to simplify the completion menu for zsh
Cleaned up the zsh completion menu by

- Removing the short options