### PR TITLE
use ${datadir} for default bash/zsh completion dirs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,8 +51,8 @@ task:
       - CC: clang
       - CC: gcc
   install_script:
-    - apk add build-base autoconf autoconf-archive automake gzip pkgconfig $CC
-              xorg-server-dev libxcomposite-dev libxext-dev libxfixes-dev
+    - apk add build-base autoconf autoconf-archive automake tar gzip pkgconfig
+              $CC xorg-server-dev libxcomposite-dev libxext-dev libxfixes-dev
               libxrandr-dev imlib2-dev
   << : *common_script
 
@@ -72,7 +72,8 @@ task:
     matrix:
       - CC: clang
       - CC: gcc
-      - CC: tcc
+      # TODO: compile tcc ourselves if debian repos don't support it
+      # - CC: tcc
   install_script:
     - apt-get update
     - apt-get install -y autoconf autoconf-archive make pkg-config $CC

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ $ ./autogen.sh clean
 ```
 
 Bash and Zsh completion scripts are available in [etc/](./etc).
-Distro packagers are encouraged to install them to the appropriate directory.
 
 ## Author ##
 

--- a/configure.ac
+++ b/configure.ac
@@ -24,14 +24,14 @@ AC_ARG_WITH([bash-completion-path],
     [AS_HELP_STRING([--with-bash-completion-path=DIR],
         [Custom installation directory for the bash completion script (Default=/usr/share/bash-completion/completions)])],
     [bash_completion_dir="$withval"],
-    [bash_completion_dir="/usr/share/bash-completion/completions"])
+    [bash_completion_dir="${datadir}/bash-completion/completions"])
 
 # Install zsh completion script
 AC_ARG_WITH([zsh-completion-path],
     [AS_HELP_STRING([--with-zsh-completion-path=DIR],
         [Custom installation directory for the zsh completion script (Default=/usr/share/zsh/site-functions)])],
     [zsh_completion_dir="$withval"],
-    [zsh_completion_dir="/usr/share/zsh/site-functions"])
+    [zsh_completion_dir="${datadir}/zsh/site-functions"])
 
 m4_pattern_forbid([^AX_],[=> GNU autoconf-archive not present. <=])
 AS_IF([test "x$orig_CFLAGS" = "x"], [


### PR DESCRIPTION
this respects the prefix and fixes `make distcheck`.