### PR TITLE
Added selection via keyboard

### DIFF
--- a/man/scrot.1
+++ b/man/scrot.1
@@ -88,6 +88,14 @@ Display help and exit.
 Don't exit for keyboard input. ESC still exits.
 .TP
 .B
+\fB-K\fP, \fB--keyboard\fP
+Enables the use of selection via keyboard. Both
+hjkl and arrow keys are valid for navigation, escape 
+exits without taking a screenshot and space will 
+start the rectangle select mode. An additional 
+press of space to finalize a screenshot.
+.TP
+.B
 \fB-k\fP, \fB--stack\fP[=\fIOPT\fP]
 Capture stack/overlapped windows and join them. A
 running Composite Manager is needed for it to work

--- a/man/scrot.1
+++ b/man/scrot.1
@@ -93,7 +93,8 @@ Enables the use of selection via keyboard. Both
 hjkl and arrow keys are valid for navigation, escape 
 exits without taking a screenshot and space will 
 start the rectangle select mode. An additional 
-press of space to finalize a screenshot.
+press of space is then required to finalize a 
+screenshot.
 .TP
 .B
 \fB-k\fP, \fB--stack\fP[=\fIOPT\fP]

--- a/src/options.c
+++ b/src/options.c
@@ -79,7 +79,7 @@ enum { /* long opt only */
     OPT_FORMAT = UCHAR_MAX + 1,
     OPT_LIST_OPTS,
 };
-static const char stropts[] = "a:bC:cD:d:e:F:fhik::l:M:mopq:s::t:uvw:Z:z";
+static const char stropts[] = "a:bC:cD:d:e:F:fhiKk::l:M:mopq:s::t:uvw:Z:z";
 // NOTE: make sure lopts and opt_description indexes are kept in sync
 static const struct option lopts[] = {
     {"autoselect",      required_argument,  NULL,   'a'},
@@ -93,6 +93,7 @@ static const struct option lopts[] = {
     {"freeze",          no_argument,        NULL,   'f'},
     {"help",            no_argument,        NULL,   'h'},
     {"ignorekeyboard",  no_argument,        NULL,   'i'},
+    {"usekeyboard",     no_argument,        NULL,   'K'},
     {"stack",           optional_argument,  NULL,   'k'},
     {"line",            required_argument,  NULL,   'l'},
     {"monitor",         required_argument,  NULL,   'M'},
@@ -128,6 +129,7 @@ static const struct option_desc {
     /* f */  { "freeze the screen when -s is used", "" },
     /* h */  { "display help and exit", "" },
     /* i */  { "ignore keyboard", "" },
+    /* K */  { "enable keyboard control", "" },
     /* k */  { "capture overlapped window and join them", "v|h" },
     /* l */  { "specify the style of the selection line", "STYLE" },
     /* M */  { "capture monitor", "NUM" },
@@ -411,6 +413,9 @@ void optionsParse(int argc, char *argv[])
             break;
         case 'i':
             opt.ignoreKeyboard = true;
+            break;
+        case 'K':
+            opt.useKeyboard = true;
             break;
         case 'k':
             opt.mode = MODE_STACK;

--- a/src/options.h
+++ b/src/options.h
@@ -98,6 +98,7 @@ struct ScrotOptions {
     bool overwrite;
     bool freeze;
     bool ignoreKeyboard;
+    bool useKeyboard;
 };
 
 extern struct ScrotOptions opt;

--- a/src/scrot.c
+++ b/src/scrot.c
@@ -107,9 +107,14 @@ int main(int argc, char *argv[])
     /* Get the time ASAP to reduce the timing error in case --delay is used. */
     opt.delayStart = clockNow();
 
-    atexit(uninitXAndImlib);
-
     optionsParse(argc, argv);
+
+    if (opt.ignoreKeyboard && opt.useKeyboard) {
+      fprintf(stderr, "scrot: can not read input from keyboard if also set to be ignored\n");
+      return 1;
+    }
+
+    atexit(uninitXAndImlib);
 
     initXAndImlib(opt.display, 0);
 

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -206,6 +206,7 @@ static bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
     enum { WAIT, DONE, ABORT } done = WAIT;
     int rx = 0, ry = 0, rw = 0, rh = 0;
     bool isButtonPressed = false;
+    bool isStartSelectionKeyPressed = false;
     unsigned int buttonId = -1;
     Window target = None;
     Status ret;
@@ -253,44 +254,72 @@ static bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
         {
             KeySym *keysym = NULL;
             int keycode; /*dummy*/
+			      struct Point p = { ev.xkey.x, ev.xkey.y };
+			      int delta = (ev.xkey.state & ControlMask) ? 1 :
+			            ((ev.xkey.state & ShiftMask) ? 128 : 16);
 
             keysym = XGetKeyboardMapping(disp, ev.xkey.keycode, 1, &keycode);
 
             if (!keysym)
                 break;
 
-            if (!isButtonPressed) {
-            key_abort_shot:
-                if (!opt.ignoreKeyboard || *keysym == XK_Escape) {
-                    warnx("Key was pressed, aborting shot");
-                    done = ABORT;
-                }
+            if (!opt.ignoreKeyboard) {
+                warnx("Key was pressed, aborting shot");
+                done = ABORT;
                 XFree(keysym);
                 break;
             }
 
             switch (*keysym) {
+            case XK_l:
             case XK_Right:
-                if (++rx > scr->width)
-                    rx = scr->width;
+                if ((p.x += delta) > scr->width)
+                    p.x = scr->width;
                 break;
+            case XK_h:
             case XK_Left:
-                if (--rx < 0)
-                    rx = 0;
+                if ((p.x -= delta) < 0)
+                    p.x = 0;
                 break;
+            case XK_j:
             case XK_Down:
-                if (++ry > scr->height)
-                    ry = scr->height;
+                if ((p.y += delta) > scr->height)
+                    p.y = scr->height;
                 break;
+            case XK_k:
             case XK_Up:
-                if (--ry < 0)
-                    ry = 0;
+                if ((p.y -= delta) < 0)
+                    p.y = 0;
+                break;
+            case XK_q:
+            case XK_Escape:
+                done = ABORT;
+                break;
+            case XK_space:
+                target = scrotGetWindow(disp, ev.xbutton.subwindow, ev.xbutton.x, ev.xbutton.y);
+                if (target == None)
+                    target = root;
+                if (!isStartSelectionKeyPressed) {
+                    isStartSelectionKeyPressed = true;
+                    rx = p.x; ry = p.y;
+                }
+                else {
+                    done = DONE;
+                }
+
                 break;
             default:
-                goto key_abort_shot;
+                break;
             }
             XFree(keysym);
-            scrotSelectionMotionDraw(rx, ry, ev.xkey.x, ev.xkey.y);
+
+            if (p.x != ev.xkey.x_root || p.y != ev.xkey.y_root) {
+                XWarpPointer(disp, None, root, 0, 0, 0, 0, p.x, p.y);
+            }
+
+            if (isStartSelectionKeyPressed && (rx != p.x || ry != p.y)) {
+                scrotSelectionMotionDraw(rx, ry, p.x, p.y);
+            }
             break;
         }
         case DestroyNotify:

--- a/src/scrot_selection.c
+++ b/src/scrot_selection.c
@@ -263,63 +263,65 @@ static bool scrotSelectionGetUserSel(struct SelectionRect *selectionRect)
             if (!keysym)
                 break;
 
-            if (!opt.ignoreKeyboard) {
+            if (opt.useKeyboard) {
+                switch (*keysym) {
+                case XK_l:
+                case XK_Right:
+                    if ((p.x += delta) > scr->width)
+                        p.x = scr->width;
+                    break;
+                case XK_h:
+                case XK_Left:
+                    if ((p.x -= delta) < 0)
+                        p.x = 0;
+                    break;
+                case XK_j:
+                case XK_Down:
+                    if ((p.y += delta) > scr->height)
+                        p.y = scr->height;
+                    break;
+                case XK_k:
+                case XK_Up:
+                    if ((p.y -= delta) < 0)
+                        p.y = 0;
+                    break;
+                case XK_q:
+                case XK_Escape:
+                    done = ABORT;
+                    break;
+                case XK_space:
+                    target = scrotGetWindow(disp, ev.xbutton.subwindow, ev.xbutton.x, ev.xbutton.y);
+                    if (target == None)
+                        target = root;
+                    if (!isStartSelectionKeyPressed) {
+                        isStartSelectionKeyPressed = true;
+                        rx = p.x; ry = p.y;
+                    }
+                    else {
+                        done = DONE;
+                    }
+                    break;
+                default:
+                    break;
+                }
+
+                if (p.x != ev.xkey.x_root || p.y != ev.xkey.y_root) {
+                    XWarpPointer(disp, None, root, 0, 0, 0, 0, p.x, p.y);
+                }
+
+                if (isStartSelectionKeyPressed && (rx != p.x || ry != p.y)) {
+                    scrotSelectionMotionDraw(rx, ry, p.x, p.y);
+                }
+            } else if (!opt.ignoreKeyboard) {
                 warnx("Key was pressed, aborting shot");
                 done = ABORT;
-                XFree(keysym);
-                break;
+            } else {
+                if (*keysym == XK_Escape) {
+                    done = ABORT;
+                }
             }
 
-            switch (*keysym) {
-            case XK_l:
-            case XK_Right:
-                if ((p.x += delta) > scr->width)
-                    p.x = scr->width;
-                break;
-            case XK_h:
-            case XK_Left:
-                if ((p.x -= delta) < 0)
-                    p.x = 0;
-                break;
-            case XK_j:
-            case XK_Down:
-                if ((p.y += delta) > scr->height)
-                    p.y = scr->height;
-                break;
-            case XK_k:
-            case XK_Up:
-                if ((p.y -= delta) < 0)
-                    p.y = 0;
-                break;
-            case XK_q:
-            case XK_Escape:
-                done = ABORT;
-                break;
-            case XK_space:
-                target = scrotGetWindow(disp, ev.xbutton.subwindow, ev.xbutton.x, ev.xbutton.y);
-                if (target == None)
-                    target = root;
-                if (!isStartSelectionKeyPressed) {
-                    isStartSelectionKeyPressed = true;
-                    rx = p.x; ry = p.y;
-                }
-                else {
-                    done = DONE;
-                }
-
-                break;
-            default:
-                break;
-            }
             XFree(keysym);
-
-            if (p.x != ev.xkey.x_root || p.y != ev.xkey.y_root) {
-                XWarpPointer(disp, None, root, 0, 0, 0, 0, p.x, p.y);
-            }
-
-            if (isStartSelectionKeyPressed && (rx != p.x || ry != p.y)) {
-                scrotSelectionMotionDraw(rx, ry, p.x, p.y);
-            }
             break;
         }
         case DestroyNotify:

--- a/src/scrot_selection.h
+++ b/src/scrot_selection.h
@@ -74,6 +74,10 @@ enum {
     SELECTION_OPACITY_DEFAULT = 100,
 };
 
+struct Point { 
+  int x, y; 
+};
+
 struct SelectionRect {
     int x, y, w, h;
 };


### PR DESCRIPTION
I wasn't sure if the ignore keyboard option, as it stands, should now be enabled by default, for now I have kept the original intent. Obviously borrows for `selx`. Let me know if there need to be further adjustments. #369.